### PR TITLE
add categorized GitHub release notes

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,6 +19,13 @@
   color: "d876e3"
   description: Support or clarification
 
+- name: breaking-change
+  color: "b60205"
+  description: Breaking change; call out in release notes
+- name: skip-changelog
+  color: "ffffff"
+  description: Exclude this PR from release notes
+
 - name: area/cli
   color: "c5def5"
   description: Commands, flags, UX copy

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,14 @@ Fixes #
 - [ ] `nix run .#lint` / pre-commit clean
 - [ ] Manual smoke (command + expected result), if user-facing
 
+## Labels
+
+<!-- Release notes group merged PRs by these labels (.github/release.yml). -->
+
+- [ ] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore`
+- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
+- [ ] Add `skip-changelog` for internal-only PRs that should not appear in notes
+
 ## Checklist
 
 - [ ] Title is short and imperative (matches commit style)

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+# Categories for GitHub automatically generated release notes.
+# Used when softprops/action-gh-release sets generate_release_notes: true,
+# or when creating a release with gh release create --generate-notes.
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - kind/chore
+      - kind/question
+      - skip-changelog
+    authors:
+      - dependabot[bot]
+      - renovate[bot]
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Features
+      labels:
+        - kind/feature
+      exclude:
+        labels:
+          - breaking-change
+    - title: Bug Fixes
+      labels:
+        - kind/bug
+    - title: Documentation
+      labels:
+        - kind/docs
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Add `.github/release.yml` so draft releases group PRs by label (Breaking Changes, Features, Bug Fixes, Documentation, Other). Add `breaking-change` and `skip-changelog` labels.

Fixes #11. AI-written highlights stay in #10.