### PR TITLE
replace gopkg.in/yaml.v3 with go.yaml.in

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/term v0.44.0
 	gopherly.dev/currus v0.8.0
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.2.1
 	k8s.io/api v0.36.2
 	k8s.io/apiextensions-apiserver v0.36.2
@@ -217,6 +216,7 @@ require (
 	gopherly.dev/termio v0.3.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.36.2 // indirect
 	k8s.io/cli-runtime v0.36.2 // indirect
 	k8s.io/component-base v0.36.2 // indirect

--- a/internal/cmd/initialize/components.go
+++ b/internal/cmd/initialize/components.go
@@ -88,10 +88,20 @@ var presetOrder = []spec.ResourcePreset{
 // manual CPU/memory/storage form instead of picking a preset.
 const customResourcesLabel = "Custom... (enter CPU/memory/storage manually)"
 
-// presetLabel formats a resource preset with its request values for
-// display in the merged resources select, e.g. "small - 500m CPU / 512Mi
-// memory".
-func presetLabel(p spec.ResourcePreset) string {
+// presetLabels maps each resource preset to its display label. Built once at
+// init so concurrent callers never race on Quantity.String against the shared
+// [spec.ResourcePresetMappings] quantities.
+var presetLabels = func() map[spec.ResourcePreset]string {
+	m := make(map[spec.ResourcePreset]string, len(presetOrder))
+	for _, p := range presetOrder {
+		m[p] = formatPresetLabel(p)
+	}
+	return m
+}()
+
+// formatPresetLabel formats a resource preset with its request values, e.g.
+// "small - 500m CPU / 512Mi memory".
+func formatPresetLabel(p spec.ResourcePreset) string {
 	req := spec.ResourcePresetMappings[p]["requests"]
 	cpu, memory := "?", "?"
 	if req.CPU != nil {
@@ -103,11 +113,19 @@ func presetLabel(p spec.ResourcePreset) string {
 	return fmt.Sprintf("%s - %s CPU / %s memory", p, cpu, memory)
 }
 
+// presetLabel returns the display label for a resource preset.
+func presetLabel(p spec.ResourcePreset) string {
+	if label, ok := presetLabels[p]; ok {
+		return label
+	}
+	return formatPresetLabel(p)
+}
+
 // presetFromLabel reverses presetLabel. It reports false when label does not
 // match any known preset (i.e. the caller picked customResourcesLabel).
 func presetFromLabel(label string) (spec.ResourcePreset, bool) {
 	for _, p := range presetOrder {
-		if presetLabel(p) == label {
+		if presetLabels[p] == label {
 			return p, true
 		}
 	}

--- a/internal/cmd/initialize/components_test.go
+++ b/internal/cmd/initialize/components_test.go
@@ -27,6 +27,18 @@ func TestPresetLabel(t *testing.T) {
 	}
 }
 
+// TestPresetLabel_UnknownFallsBackToFormat covers the presetLabel path when
+// the preset is not in the precomputed map (for example a typo or a new
+// preset not yet added to presetOrder).
+func TestPresetLabel_UnknownFallsBackToFormat(t *testing.T) {
+	t.Parallel()
+
+	unknown := spec.ResourcePreset("not-a-real-preset")
+	got := presetLabel(unknown)
+	assert.Equal(t, formatPresetLabel(unknown), got)
+	assert.Equal(t, "not-a-real-preset - ? CPU / ? memory", got)
+}
+
 // TestPresetFromLabel verifies presetLabel and presetFromLabel are inverse
 // operations for every known preset, and that presetFromLabel rejects the
 // "Custom..." label and arbitrary strings.

--- a/internal/helm/generate.go
+++ b/internal/helm/generate.go
@@ -16,7 +16,7 @@ import (
 	"text/template"
 
 	"github.com/distribution/reference"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"deployah.dev/deployah/internal/spec"

--- a/internal/plan/diff.go
+++ b/internal/plan/diff.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gonvenience/ytbx"
 	"github.com/homeport/dyff/pkg/dyff"
 
+	// TODO(#14): migrate native YAML to go.yaml.in/yaml/v4 once dyff/ytbx do.
 	yamlv3 "go.yaml.in/yaml/v3"
 	v1 "helm.sh/helm/v4/pkg/release/v1"
 )

--- a/internal/spec/profile_test.go
+++ b/internal/spec/profile_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"deployah.dev/deployah/internal/spec"
 

--- a/internal/spec/quantity.go
+++ b/internal/spec/quantity.go
@@ -20,8 +20,15 @@ import (
 
 // MustQuantity parses s as a Kubernetes quantity pointer. Panics on invalid
 // input; use only for compile-time constants such as resource presets.
+//
+// The returned value has its String cache warmed. resource.Quantity.String
+// writes that cache on first use, so concurrent String calls on shared
+// package-level quantities (for example [ResourcePresetMappings]) would
+// otherwise race.
 func MustQuantity(s string) *resource.Quantity {
-	return new(resource.MustParse(s))
+	q := resource.MustParse(s)
+	_ = q.String()
+	return &q
 }
 
 // quantitySet reports whether q is a non-nil, non-zero quantity.

--- a/internal/testing/plan_scenarios.go
+++ b/internal/testing/plan_scenarios.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"deployah.dev/deployah/internal/extras"
 	"deployah.dev/deployah/internal/helm"

--- a/internal/testing/scenario_discovery.go
+++ b/internal/testing/scenario_discovery.go
@@ -23,7 +23,7 @@ import (
 	"slices"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"deployah.dev/deployah/internal/spec"
 )

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"deployah.dev/deployah/internal/extras"


### PR DESCRIPTION
Replace direct `gopkg.in/yaml.v3` imports with `go.yaml.in/yaml/v3`. Keep `sigs.k8s.io/yaml` for the JSON-bridge path. Warm the `resource.Quantity` String cache so concurrent preset labels do not race.

Fixes #13. Native YAML v4 is #14.