### PR TITLE
add nginx example and README demo GIFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
-# Deployah config (keep scenario and e2e fixtures tracked for CI)
+# Deployah config (keep scenario, e2e, and example fixtures tracked)
 deployah.platform.yaml
 deployah.yaml
 .env.*
 .env
-# Only the repo-root scaffold; fixture trees under scenarios/ and
-# internal/e2e/testdata/ keep their .deployah/ contents tracked.
+# Only the repo-root scaffold; fixture trees under scenarios/,
+# internal/e2e/testdata/, and examples/ keep their tracked contents.
 /.deployah/
 !scenarios/**/deployah.platform.yaml
 !scenarios/**/deployah.yaml
@@ -14,6 +14,15 @@ deployah.yaml
 !internal/e2e/testdata/**/deployah.yaml
 !internal/e2e/testdata/**/.env.*
 !internal/e2e/testdata/**/.env
+!examples/**/deployah.yaml
+!examples/**/deployah.platform.yaml
+!examples/**/.env.*
+!examples/**/.env
+
+# VHS demo renders (regenerate with: nix run .#demo)
+docs/assets/*.gif
+docs/assets/*.mp4
+docs/assets/*.webm
 
 # Go workspace file
 go.work

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/deployah-dev/deployah/badge)](https://scorecard.dev/viewer/?uri=github.com/deployah-dev/deployah)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/deployah-dev/deployah)
 
+<!-- markdownlint-disable MD033 -->
+<p align="center">
+  <img src="https://deployah.dev/demos/nginx.gif" alt="Deployah: write a short nginx spec, deploy to a local cluster, get a URL" width="800">
+</p>
+<!-- markdownlint-enable MD033 -->
+
 **Zero Helm knowledge. Zero cluster-side setup. One binary.**
 
 Deployah is a CLI that deploys apps to Kubernetes. It sits in the gap between
@@ -21,6 +27,7 @@ but for the deploy step: S2I builds your image, and Deployah runs your release.
 - [Installation](#installation)
 - [Requirements](#requirements)
 - [Quick start](#quick-start)
+- [Examples](#examples)
 - [How Deployah works](#how-deployah-works)
 - [Concepts](#concepts)
 - [Writing your spec](#writing-your-spec)
@@ -152,6 +159,12 @@ deployah delete my-first-app local
 # Stop and delete the local cluster
 deployah cluster down
 ```
+
+## Examples
+
+Runnable specs live under [`examples/`](examples/). Start with
+[`examples/nginx`](examples/nginx): the same flow as the quick start, ready to
+copy.
 
 ## How Deployah works
 
@@ -1553,6 +1566,8 @@ Set `DEPLOYAH_E2E_DUMP=1` with `-v` to print live objects when adding a scenario
 ```sh
 nix build              # build the deployah binary
 nix run . -- --help    # run without installing
+nix run .#demo         # render docs/demo/tapes into docs/assets/ (see docs/demo)
+nix run .#publish-demo # sync docs/assets/ to R2 (needs R2_* env vars)
 ```
 
 ### CI

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,0 +1,53 @@
+# Demo GIFs
+
+Terminal demos for the README and docs. Tapes live under
+[`tapes/`](tapes/). Rendered GIFs go to [`../assets/`](../assets/) and are
+published to `https://deployah.dev/demos/`.
+
+Shared VHS settings live in [`tapes/_common.tape`](tapes/_common.tape)
+(`Source`d by each demo; files starting with `_` are not rendered on their
+own).
+
+Examples under [`examples/`](../../examples/) are general-purpose starters.
+Demos reuse them (for example [`examples/nginx`](../../examples/nginx)) so the
+recording matches what people run by hand.
+
+## Render locally
+
+Docker or Podman must be running. From the repo root:
+
+```sh
+nix run .#demo
+```
+
+That runs every `docs/demo/tapes/*.tape` (except `_*.tape`) with
+[VHS](https://github.com/charmbracelet/vhs) under `xvfb-run`, and writes
+optimized GIFs to `docs/assets/`. Tapes may use
+`bat`, `jq`, `curl`, and `xclip` (provided by `nix run .#demo`).
+
+`xvfb-run` supplies a DISPLAY so `xclip` and VHS `Paste` share a clipboard
+(used to show the curl line with the real gateway port).
+
+## Publish
+
+Upload `docs/assets/` to the CDN (Cloudflare R2 or any S3-compatible bucket):
+
+```sh
+export R2_ACCESS_KEY_ID=...
+export R2_SECRET_ACCESS_KEY=...
+export R2_ENDPOINT_URL=...
+export R2_BUCKET=deployah
+export R2_DEST_PATH=demos/
+nix run .#publish-demo
+```
+
+The README embeds `https://deployah.dev/demos/nginx.gif`. After the first
+publish, that URL should resolve.
+
+## Adding a tape
+
+1. Prefer an existing example under `examples/`, or add a new one.
+2. Add `docs/demo/tapes/<name>.tape` with `Output docs/assets/<name>.gif` and
+   `Source docs/demo/tapes/_common.tape`.
+3. Run `nix run .#demo` and check the GIF.
+4. Run `nix run .#publish-demo` when you want the CDN updated.

--- a/docs/demo/tapes/_common.tape
+++ b/docs/demo/tapes/_common.tape
@@ -1,0 +1,18 @@
+# Shared VHS settings for Deployah demos.
+# Sourced by docs/demo/tapes/*.tape (files starting with _ are not rendered).
+# Run demos from the repo root: nix run .#demo
+
+Set Shell "bash"
+Set FontSize 16
+Set Margin 10
+Set Padding 10
+Set BorderRadius 15
+Set Width 1400
+Set Height 700
+Set Theme "Dracula"
+Set WindowBar Colorful
+Set TypingSpeed 55ms
+Set CursorBlink false
+Set Framerate 12
+# Kind create + first deploy can take several minutes (default WaitTimeout is 15s).
+Set WaitTimeout 15m

--- a/docs/demo/tapes/nginx.tape
+++ b/docs/demo/tapes/nginx.tape
@@ -1,0 +1,79 @@
+# README demo using examples/nginx
+# Render with: nix run .#demo
+# Requires Docker or Podman.
+#
+# Wait on the shell prompt after long commands: deployah's Status UI (Bubble Tea)
+# can leave "Deployed" invisible to VHS screen scrapes even after a successful deploy.
+# Paste + xclip shows the curl line with the real gateway port (VHS Up prints ^[[A here).
+Output docs/assets/nginx.gif
+
+Require deployah
+Require bat
+Require jq
+Require curl
+Require xclip
+
+Source docs/demo/tapes/_common.tape
+
+# --- off camera: workdir + local cluster ---
+# Delete any prior release so the on-camera deploy is a real install.
+# Unique PS1 so Wait can detect command completion reliably.
+Hide
+Type "cd examples/nginx"
+Enter
+Sleep 300ms
+Type `export PS1='demo> '`
+Enter
+Sleep 200ms
+Type `alias cat='bat --paging=never --style=numbers,grid --theme=Dracula --language=yaml'`
+Enter
+Sleep 200ms
+Type "deployah cluster up"
+Enter
+Wait /demo>/
+Type "deployah delete nginx local --yes >/dev/null 2>&1 || true"
+Enter
+Wait /demo>/
+Type "clear"
+Enter
+Sleep 300ms
+Show
+
+# --- on camera ---
+Type@70ms "cat deployah.yaml"
+Enter
+Sleep 2.5s
+
+Type "deployah validate local"
+Enter
+Wait /demo>/
+Sleep 1s
+
+Type "deployah deploy local --yes"
+Enter
+Wait /demo>/
+Sleep 1.5s
+
+# Capture gateway port and put the expanded curl on the X11 clipboard for Paste.
+Hide
+Type `PORT=$(deployah cluster status -o json | jq -r '.access[0].address|split(":")[1]')`
+Enter
+Wait /demo>/
+Type `printf 'curl -ksI --resolve web.127.0.0.1.nip.io:%s:127.0.0.1 https://web.127.0.0.1.nip.io:%s' "$PORT" "$PORT" | xclip -selection clipboard`
+Enter
+Wait /demo>/
+Type "clear"
+Enter
+Sleep 300ms
+Show
+
+Type "deployah cluster status"
+Enter
+Wait /demo>/
+Sleep 2s
+
+Paste
+Sleep 1.5s
+Enter
+Wait /demo>/
+Sleep 6s

--- a/examples/nginx/README.md
+++ b/examples/nginx/README.md
@@ -1,0 +1,26 @@
+# Nginx example
+
+Deploys the public `nginx:latest` image to a local Deployah cluster with HTTPS
+via `expose: true`.
+
+## Run it
+
+You need Docker or Podman. From the repo root:
+
+```sh
+cd examples/nginx
+deployah cluster up
+deployah deploy local --yes
+deployah cluster status
+```
+
+`deployah cluster up` creates `deployah.platform.yaml` in this directory with a
+`local` environment. Open the URL printed by `deployah cluster status` to see
+the nginx welcome page.
+
+## Clean up
+
+```sh
+deployah delete nginx local --yes
+deployah cluster down --force
+```

--- a/examples/nginx/deployah.platform.yaml
+++ b/examples/nginx/deployah.platform.yaml
@@ -1,0 +1,9 @@
+apiVersion: platform/v1-alpha.1
+environments:
+  local:
+    context: kind-deployah
+    domains:
+      public:
+        baseDomain: 127.0.0.1.nip.io
+        tls:
+          mode: selfSigned

--- a/examples/nginx/deployah.yaml
+++ b/examples/nginx/deployah.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1-alpha.2
+project: nginx
+components:
+  web:
+    image: nginx:latest
+    port: 80
+    environments: [local]
+    expose: true

--- a/nix/apps/default.nix
+++ b/nix/apps/default.nix
@@ -11,6 +11,7 @@ let
   quality = import ./quality.nix { inherit pkgs lib; };
   testing = import ./testing.nix { inherit lib; };
   vendor = import ./vendor.nix { inherit pkgs system; };
+  demo = import ./demo.nix { inherit pkgs lib deployah; };
 in
 {
   default = flake-utils.lib.mkApp {
@@ -21,3 +22,4 @@ in
 // quality
 // testing
 // vendor
+// demo

--- a/nix/apps/demo.nix
+++ b/nix/apps/demo.nix
@@ -1,0 +1,87 @@
+# Demo GIF rendering and CDN publish apps
+{
+  pkgs,
+  lib,
+  deployah,
+}:
+
+{
+  demo = lib.mkApp {
+    name = "demo";
+    description = "Render docs/demo/tapes/*.tape into docs/assets/ (needs Docker or Podman)";
+    runtimeInputs = [
+      deployah
+      pkgs.vhs
+      pkgs.gifsicle
+      pkgs.bat
+      pkgs.jq
+      pkgs.curl
+      pkgs.xclip
+      pkgs.xvfb-run
+    ];
+    script = ''
+      set -euo pipefail
+
+      if [ ! -d docs/demo/tapes ]; then
+        echo "run from the repo root (docs/demo/tapes not found)" >&2
+        exit 1
+      fi
+
+      mkdir -p docs/assets
+
+      shopt -s nullglob
+      tapes=(docs/demo/tapes/*.tape)
+      if [ ''${#tapes[@]} -eq 0 ]; then
+        echo "no tape files in docs/demo/tapes/" >&2
+        exit 1
+      fi
+
+      for tape in "''${tapes[@]}"; do
+        base="$(basename "$tape")"
+        # Shared snippets (e.g. _common.tape) are Source'd, not rendered alone.
+        case "$base" in
+          _*) continue ;;
+        esac
+        echo "Rendering $tape ..."
+        # xvfb gives DISPLAY so xclip + VHS Paste share a clipboard.
+        xvfb-run -a vhs "$tape"
+      done
+
+      for gif in docs/assets/*.gif; do
+        echo "Optimizing $gif ..."
+        gifsicle -O3 --lossy=40 --colors 128 "$gif" -o "$gif"
+      done
+
+      echo "Done. GIFs are under docs/assets/"
+    '';
+  };
+
+  publish-demo = lib.mkApp {
+    name = "publish-demo";
+    description = "Sync docs/assets/ to R2 (requires R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT_URL, R2_BUCKET, R2_DEST_PATH)";
+    runtimeInputs = [ pkgs.awscli2 ];
+    script = ''
+      set -euo pipefail
+
+      : "''${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required}"
+      : "''${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}"
+      : "''${R2_ENDPOINT_URL:?R2_ENDPOINT_URL is required}"
+      : "''${R2_BUCKET:?R2_BUCKET is required}"
+      : "''${R2_DEST_PATH:?R2_DEST_PATH is required}"
+
+      if [ ! -d docs/assets ]; then
+        echo "docs/assets/ missing; run nix run .#demo first" >&2
+        exit 1
+      fi
+
+      export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+      export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+      export AWS_DEFAULT_REGION="auto"
+
+      exec aws s3 sync docs/assets/ \
+        "s3://$R2_BUCKET/$R2_DEST_PATH" \
+        --endpoint-url "$R2_ENDPOINT_URL" \
+        --exclude ".gitkeep"
+    '';
+  };
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -20,6 +20,11 @@ let
     kubernetes-helm
     jq
     yq-go
+    vhs
+    gifsicle
+    bat
+    xclip
+    xvfb-run
   ];
 in
 pkgs.mkShell {


### PR DESCRIPTION
Add a runnable `examples/nginx` starter. Add VHS demo tooling (`nix run .#demo`) so README GIFs can be regenerated and synced to `deployah.dev/demos/`. Embed the nginx demo in the README.