### PR TITLE
add OSV-Scanner CI for deps and images

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,19 @@
+name: OSV-Scanner PR Scan
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
+jobs:
+  scan-pr:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -1,0 +1,21 @@
+name: OSV-Scanner Scheduled Scan
+
+on:
+  schedule:
+    - cron: "30 12 * * 1"
+  push:
+    branches: [main]
+
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
+jobs:
+  scan-scheduled:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      fail-on-vuln: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,87 @@ permissions:
   contents: read
 
 jobs:
+  osv-container-scan:
+    name: OSV Container Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+            max-parallelism = 10
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          else
+            echo "VERSION=dev" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build linux/amd64 image for scan
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7
+        with:
+          targets: image
+          load: true
+          provenance: false
+          vars: |
+            VERSION=${{ env.VERSION }}
+          set: |
+            image.platform=linux/amd64
+            image.tags=deployah/deployah:osv-scan
+            image.cache-from=type=gha,scope=image
+            image.cache-to=type=gha,mode=max,scope=image
+
+      - name: Save image archive
+        run: docker save deployah/deployah:osv-scan -o deployah-amd64.tar
+
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
+        continue-on-error: true
+        with:
+          scan-args: |-
+            scan
+            image
+            --config=./osv-scanner.toml
+            --output=results.json
+            --format=json
+            --archive
+            ./deployah-amd64.tar
+
+      - name: Report OSV-Scanner results
+        uses: google/osv-scanner-action/osv-reporter-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
+        with:
+          scan-args: |-
+            --output=results.sarif
+            --new=results.json
+            --gh-annotations=false
+            --fail-on-vuln=true
+
+      - name: Upload SARIF
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          sarif_file: results.sarif
+          category: osv-scanner-container
+
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: [osv-container-scan]
     permissions:
       contents: write
       packages: write

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,5 @@
+# OSV-Scanner configuration. See https://google.github.io/osv-scanner/configuration/
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "golang.org/x/crypto/openpgp is uncalled (transitive only); advisory has no fixed version"


### PR DESCRIPTION
Add OSV-Scanner PR differential scan, weekly/`main` full source scan, and a linux/amd64 image scan on Release. Ignore uncalled `GO-2026-5932` so image scans stay actionable.

Fixes #60.