### PR TITLE
bump Go toolchain to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS base
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS base
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 COPY --from=xx / /

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module deployah.dev/deployah
 
-go 1.26.3
+go 1.26.5
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Bump `go` from 1.26.3 to 1.26.5 to clear reachable stdlib advisories that failed the OSV scheduled scan. Align the Dockerfile tag to `golang:1.26.5-alpine`.

Fixes #62. Later superseded by the Go 1.27 bump (#68).