### PR TITLE
add CODEOWNERS for default review ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in the repo.
+# Used when "Require review from Code Owners" is enabled on main.
+* @atkrad


### PR DESCRIPTION
Add `.github/CODEOWNERS` with `@atkrad` as default owner. Prepares Scorecard "Require review from Code Owners". Do not turn that on while solo.