### PR TITLE
add codecov test analytics uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,9 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: [validate]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -160,10 +163,25 @@ jobs:
           path: coverage-unit.out
           retention-days: 1
 
+      - name: Upload unit test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          use_oidc: true
+          fail_ci_if_error: true
+          report_type: test_results
+          files: ./junit-unit.xml
+          flags: unittests
+          name: deployah-unit-tests
+          disable_search: true
+
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: [validate]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -192,10 +210,25 @@ jobs:
           path: coverage-integration.out
           retention-days: 1
 
+      - name: Upload integration test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          use_oidc: true
+          fail_ci_if_error: true
+          report_type: test_results
+          files: ./junit-integration.xml
+          flags: integration
+          name: deployah-integration-tests
+          disable_search: true
+
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [validate]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -228,6 +261,18 @@ jobs:
           name: coverage-e2e
           path: coverage-e2e.out
           retention-days: 1
+
+      - name: Upload e2e test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          use_oidc: true
+          fail_ci_if_error: true
+          report_type: test_results
+          files: ./junit-e2e.xml
+          flags: e2e
+          name: deployah-e2e-tests
+          disable_search: true
 
   report:
     name: Coverage Report

--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,8 @@ go.work.sum
 coverage*.out
 coverage*.html
 
+# JUnit reports (Codecov Test Analytics)
+junit*.xml
+
 # Pre-commit config
 .pre-commit-config.yaml

--- a/nix/apps/testing.nix
+++ b/nix/apps/testing.nix
@@ -4,24 +4,27 @@
 {
   test-unit = lib.mkTaggedRaceTest {
     name = "test-unit";
-    description = "Run unit tests with race detector; write coverage-unit.out (build tag !integration)";
+    description = "Run unit tests with race detector; write coverage-unit.out and junit-unit.xml (build tag !integration)";
     tags = "!integration";
     coverProfile = "coverage-unit.out";
+    junitFile = "junit-unit.xml";
   };
 
   test-integration = lib.mkTaggedRaceTest {
     name = "test-integration";
-    description = "Run integration tests with race detector; write coverage-integration.out (build tag integration)";
+    description = "Run integration tests with race detector; write coverage-integration.out and junit-integration.xml (build tag integration)";
     tags = "integration";
     coverProfile = "coverage-integration.out";
+    junitFile = "junit-integration.xml";
     testPackages = "./internal/testing";
   };
 
   test-e2e = lib.mkTaggedRaceTest {
     name = "test-e2e";
-    description = "Run e2e tests against a live Kind cluster; write coverage-e2e.out";
+    description = "Run e2e tests against a live Kind cluster; write coverage-e2e.out and junit-e2e.xml";
     tags = "e2e";
     coverProfile = "coverage-e2e.out";
+    junitFile = "junit-e2e.xml";
     testPackages = "./internal/e2e";
     timeout = "15m";
     race = false; # the work is a live cluster, not concurrent Go

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -30,6 +30,7 @@ rec {
       description,
       tags,
       coverProfile,
+      junitFile,
       testPackages ? "./...",
       timeout ? "10m",
       race ? true,
@@ -39,6 +40,7 @@ rec {
       runtimeInputs = [
         go
         pkgs.stdenv.cc
+        pkgs.gotestsum
       ];
       script = ''
         export GOTOOLCHAIN=local
@@ -51,7 +53,9 @@ rec {
           echo "go list: no test packages after filters (tags=${tags})" >&2
           exit 1
         fi
-        exec "$go/bin/go" test -tags=${tags} ${pkgs.lib.optionalString race "-race"} \
+        # gotestsum writes JUnit XML for Codecov Test Analytics even when tests fail.
+        exec gotestsum --junitfile=${junitFile} -- \
+          -tags=${tags} ${pkgs.lib.optionalString race "-race"} \
           -shuffle=on -covermode=atomic \
           -coverpkg=./... -coverprofile=${coverProfile} -timeout ${timeout} "''${testpkgs[@]}"
       '';


### PR DESCRIPTION
Emit JUnit XML from `nix run .#test-{unit,integration,e2e}` via `gotestsum`. Upload test results from each CI job over OIDC, including failed runs. Coverage uploads stay.