### PR TITLE
extract workspace loading from session

### DIFF
--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -92,7 +92,7 @@ func runDeploy(c *nabat.Context) error {
 
 	// Prescan the raw (pre-envsubst) manifest for ${VAR} tokens so the
 	// resolver can distinguish static from dynamic subdomains.
-	rawSpec, _, rawErr := spec.ParseManifest(sess.SpecPath())
+	rawSpec, rawErr := sess.ParseManifest()
 	if rawErr != nil {
 		return fmt.Errorf("parse manifest: %w", rawErr)
 	}

--- a/internal/cmd/plan/plan.go
+++ b/internal/cmd/plan/plan.go
@@ -118,7 +118,7 @@ func runPlan(c *nabat.Context) error {
 	// Prescan the raw (pre-envsubst) manifest for ${VAR} tokens so the
 	// resolver can distinguish static from dynamic subdomains, matching
 	// deploy's resolution behavior.
-	rawSpec, _, rawErr := spec.ParseManifest(sess.SpecPath())
+	rawSpec, rawErr := sess.ParseManifest()
 	if rawErr != nil {
 		return fmt.Errorf("parse manifest: %w", rawErr)
 	}

--- a/internal/cmd/resolve/resolve.go
+++ b/internal/cmd/resolve/resolve.go
@@ -90,7 +90,7 @@ func runResolve(c *nabat.Context) error {
 
 	// Raw manifest is only for the substitution prescan. Resolution must
 	// see the substituted spec so ${...} in env and envFile match deploy.
-	rawSpec, _, err := spec.ParseManifest(sess.SpecPath())
+	rawSpec, err := sess.ParseManifest()
 	if err != nil {
 		return fmt.Errorf("load manifest: %w", err)
 	}
@@ -365,7 +365,7 @@ func buildEnvironmentOverview(rawSpec *spec.Spec, platform *spec.PlatformConfig,
 // runEnvironmentsOverview prints every environment from the spec and
 // platform files in the requested output format.
 func runEnvironmentsOverview(c *nabat.Context, sess *session.Session, output string) error {
-	rawSpec, _, err := spec.ParseManifest(sess.SpecPath())
+	rawSpec, err := sess.ParseManifest()
 	if err != nil {
 		return fmt.Errorf("load manifest: %w", err)
 	}

--- a/internal/cmd/validate/validate.go
+++ b/internal/cmd/validate/validate.go
@@ -89,7 +89,7 @@ func runManifestOnly(c *nabat.Context, rt *session.Session) error {
 	// Cross-field and platform checks are best-effort here: they need the
 	// raw (pre-substitution) spec, so a manifest that only unmarshals after
 	// ${VAR} substitution skips them with a warning.
-	rawSpec, _, parseErr := spec.ParseManifest(specPath)
+	rawSpec, parseErr := rt.ParseManifest()
 	if parseErr != nil {
 		c.Warn(fmt.Sprintf("skipping cross-field checks: %v", parseErr))
 	} else {
@@ -124,7 +124,7 @@ func runManifestOnly(c *nabat.Context, rt *session.Session) error {
 // the named environment. A missing platform file is allowed when the spec
 // does not use platform-owned features.
 func runCrossFile(c *nabat.Context, rt *session.Session, environment string) error {
-	rawSpec, _, err := spec.ParseManifest(rt.SpecPath())
+	rawSpec, err := rt.ParseManifest()
 	if err != nil {
 		return fmt.Errorf("manifest invalid: %w", err)
 	}

--- a/internal/session/doc.go
+++ b/internal/session/doc.go
@@ -19,6 +19,7 @@
 // configured environment per invocation. Construct one with [New], attach it
 // via [WithContext], and retrieve it in handlers through [FromContext].
 //
+// Spec and platform source loading is delegated to [workspace.Workspace].
 // Kubernetes destination resolution is delegated to [target.Resolver]. Call
 // [Session.Target] with the environment name to obtain a [Cluster] that wraps
 // the resolved [target.Target] and lazily constructs Helm and Kubernetes

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -3,8 +3,6 @@ package session
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -14,6 +12,7 @@ import (
 	"deployah.dev/deployah/internal/helm"
 	"deployah.dev/deployah/internal/spec"
 	"deployah.dev/deployah/internal/target"
+	"deployah.dev/deployah/internal/workspace"
 )
 
 // sessionKey is a private context key for storing the Session in context.
@@ -36,22 +35,22 @@ const (
 // It is created once in the root pre-run hook and travels through
 // [context.Context] so every command shares one configured environment.
 //
+// Spec and platform source loading is delegated to [workspace.Workspace].
+// Kubernetes destination resolution is delegated to [target.Resolver].
 // To access Helm or Kubernetes clients, call [Session.Target] first.
 type Session struct {
+	workspaceConfig workspace.Config
+	workspace       *workspace.Workspace
+
 	namespace            string
 	kubeconfig           string
 	kubeContext          string
 	extraKubeconfigPaths []string
-	specPath             string
-	platformPath         string
 	commandPolicy        CommandPolicy
 
 	storageDriver string
 	debug         bool
 	timeout       time.Duration
-
-	platform *spec.PlatformConfig
-	mu       sync.Mutex
 
 	helmFactory func(*Session) (HelmClient, error)
 	k8sFactory  func(*target.Target) (kubernetes.Interface, error)
@@ -89,13 +88,13 @@ func WithExtraKubeconfigPaths(paths ...string) Option {
 
 // WithSpecPath sets the spec file path.
 func WithSpecPath(specPath string) Option {
-	return func(s *Session) { s.specPath = specPath }
+	return func(s *Session) { s.workspaceConfig.SpecPath = specPath }
 }
 
 // WithPlatformFile sets an explicit platform file path, overriding both the
 // DEPLOYAH_PLATFORM_FILE environment variable and the same-directory default.
 func WithPlatformFile(path string) Option {
-	return func(s *Session) { s.platformPath = path }
+	return func(s *Session) { s.workspaceConfig.PlatformPath = path }
 }
 
 // WithCommandPolicy sets the platform-missing policy for this session.
@@ -135,6 +134,7 @@ func WithKubernetesFactory(factory func(*target.Target) (kubernetes.Interface, e
 }
 
 // New constructs a Session with the given functional options.
+// The composed [workspace.Workspace] is created after all options are applied.
 func New(options ...Option) *Session {
 	s := &Session{
 		storageDriver: DefaultStorageDriver,
@@ -145,6 +145,7 @@ func New(options ...Option) *Session {
 	for _, opt := range options {
 		opt(s)
 	}
+	s.workspace = workspace.New(s.workspaceConfig)
 	return s
 }
 
@@ -163,52 +164,11 @@ func FromContext(ctx context.Context) *Session {
 	return nil
 }
 
-// Platform loads and memoizes the platform configuration. It resolves the
-// platform file path from (in order of precedence):
-//  1. An explicit path set via [WithPlatformFile].
-//  2. The DEPLOYAH_PLATFORM_FILE environment variable.
-//  3. The same directory as the spec file (deployah.platform.yaml).
-//
-// When no platform file is found, Platform returns (nil, nil). Only when a
-// path is found but fails to load does it return an error.
+// Platform loads and memoizes the platform configuration through the
+// composed [workspace.Workspace]. See [workspace.Workspace.Platform] for
+// required versus optional source semantics.
 func (s *Session) Platform() (*spec.PlatformConfig, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.platform != nil {
-		return s.platform, nil
-	}
-	explicit := s.platformPath != "" || os.Getenv(spec.PlatformEnvVar) != ""
-	path := s.resolvePlatformPath()
-	if !explicit {
-		// The default-path lookup treats an absent file as "no platform
-		// config"; only an explicitly named file must exist.
-		if _, err := os.Stat(path); err != nil {
-			return nil, nil //nolint:nilnil // absent platform file is not an error; callers check for nil config
-		}
-	}
-	p, err := spec.LoadPlatform(path)
-	if err != nil {
-		return nil, err
-	}
-	s.platform = p
-	return p, nil
-}
-
-// resolvePlatformPath returns the platform file path following the lookup
-// precedence rule. It is called with s.mu held.
-func (s *Session) resolvePlatformPath() string {
-	if s.platformPath != "" {
-		return s.platformPath
-	}
-	if envPath := os.Getenv(spec.PlatformEnvVar); envPath != "" {
-		return envPath
-	}
-	// Same directory as the spec file.
-	if s.specPath != "" {
-		dir := filepath.Dir(s.specPath)
-		return filepath.Join(dir, spec.DefaultPlatformPath)
-	}
-	return spec.DefaultPlatformPath
+	return s.workspace.Platform()
 }
 
 // Spec loads the spec for [Session.SpecPath] and environment. Each call loads
@@ -216,15 +176,7 @@ func (s *Session) resolvePlatformPath() string {
 // selects different env files per environment). The platform config, when
 // present, supplies the environment registry.
 func (s *Session) Spec(ctx context.Context, environment string) (*spec.Spec, error) {
-	platform, err := s.Platform()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load platform file: %w", err)
-	}
-	m, err := spec.Load(ctx, s.SpecPath(), environment, platform)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load spec: %w", err)
-	}
-	return m, nil
+	return s.workspace.LoadSpec(ctx, environment)
 }
 
 // Target resolves the Kubernetes destination for env and returns a [Cluster]
@@ -253,22 +205,16 @@ func (s *Session) targetConfig() target.Config {
 	}
 }
 
-// SpecPath returns the spec file path. When unset, it returns
-// [spec.DefaultSpecPath].
+// SpecPath returns the effective spec file path from the composed Workspace.
+// The path is never empty; an unset option defaults to [spec.DefaultSpecPath].
 func (s *Session) SpecPath() string {
-	if s.specPath == "" {
-		return spec.DefaultSpecPath
-	}
-	return s.specPath
+	return s.workspace.SpecPath()
 }
 
-// PlatformPath returns the platform file path using the same lookup as
-// [Session.Platform]: an explicit --platform-file, then
-// DEPLOYAH_PLATFORM_FILE, then deployah.platform.yaml next to the spec.
+// PlatformPath returns the snapshotted platform file path from the
+// composed Workspace.
 func (s *Session) PlatformPath() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.resolvePlatformPath()
+	return s.workspace.PlatformPath()
 }
 
 // ParseManifest reads and partially validates the spec (apiVersion +
@@ -276,11 +222,7 @@ func (s *Session) PlatformPath() string {
 // that need the raw manifest structure without environment-specific processing
 // (e.g. validate manifest-only mode, substitution prescan).
 func (s *Session) ParseManifest() (*spec.Spec, error) {
-	rawSpec, _, err := spec.ParseManifest(s.SpecPath())
-	if err != nil {
-		return nil, err
-	}
-	return rawSpec, nil
+	return s.workspace.ParseManifest()
 }
 
 // KubeContext returns the explicit kube context override, or empty string if
@@ -294,25 +236,17 @@ func (s *Session) DebugKeepTempChart() bool { return s.debug }
 // Timeout returns the configured timeout for Helm operations.
 func (s *Session) Timeout() time.Duration { return s.timeout }
 
-// Close releases memoized resources held by the session.
-func (s *Session) Close() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.platform = nil
-	return nil
-}
-
 // cloneWithContext returns a shallow copy of s with the given kubeContext
 // applied, clearing any cached clients. Used by Cluster to build clients
 // with the resolved context without mutating the original session.
+// The clone shares the same [workspace.Workspace].
 func (s *Session) cloneWithContext(kubeContext string) *Session {
 	return &Session{
+		workspace:            s.workspace,
 		namespace:            s.namespace,
 		kubeconfig:           s.kubeconfig,
 		kubeContext:          kubeContext,
 		extraKubeconfigPaths: s.extraKubeconfigPaths,
-		specPath:             s.specPath,
-		platformPath:         s.platformPath,
 		storageDriver:        s.storageDriver,
 		debug:                s.debug,
 		timeout:              s.timeout,

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -578,6 +578,63 @@ func TestPlatformPathAccessor(t *testing.T) {
 	}
 }
 
+func TestSessionConstructsWorkspaceAfterOptions(t *testing.T) {
+	t.Parallel()
+
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	platformPath := filepath.Join(t.TempDir(), "custom.platform.yaml")
+	sess := New(WithSpecPath(specPath), WithPlatformFile(platformPath))
+	assert.Equal(t, specPath, sess.SpecPath())
+	assert.Equal(t, platformPath, sess.PlatformPath())
+}
+
+func TestSessionPlatformDelegation(t *testing.T) {
+	t.Parallel()
+
+	platformPath := filepath.Join(t.TempDir(), "deployah.platform.yaml")
+	require.NoError(t, writeFile(platformPath, platformContextYAML("prod-eks")))
+	sess := New(WithPlatformFile(platformPath))
+	p, err := sess.Platform()
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "prod-eks", spec.PlatformEnvContext(p, "production"))
+}
+
+func TestSessionPlatformMemoized(t *testing.T) {
+	t.Parallel()
+
+	platformPath := filepath.Join(t.TempDir(), "deployah.platform.yaml")
+	require.NoError(t, writeFile(platformPath, platformContextYAML("prod-eks")))
+	sess := New(WithPlatformFile(platformPath))
+
+	first, err := sess.Platform()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	require.NoError(t, os.Remove(platformPath))
+	second, err := sess.Platform()
+	require.NoError(t, err)
+	assert.Same(t, first, second)
+}
+
+func TestCloneWithContextSharesWorkspace(t *testing.T) {
+	pathA := filepath.Join(t.TempDir(), "a.platform.yaml")
+	pathB := filepath.Join(t.TempDir(), "b.platform.yaml")
+	require.NoError(t, writeFile(pathA, platformContextYAML("context-a")))
+	require.NoError(t, writeFile(pathB, platformContextYAML("context-b")))
+
+	t.Setenv(spec.PlatformEnvVar, pathA)
+	sess := New()
+	clone := sess.cloneWithContext("other")
+	assert.Same(t, sess.workspace, clone.workspace)
+
+	t.Setenv(spec.PlatformEnvVar, pathB)
+	assert.Equal(t, pathA, clone.PlatformPath())
+	p, err := clone.Platform()
+	require.NoError(t, err)
+	assert.Equal(t, "context-a", spec.PlatformEnvContext(p, "production"))
+}
+
 // TestKubeContextAccessor verifies KubeContext returns the explicit
 // override only, independent of kubeconfig resolution.
 func TestKubeContextAccessor(t *testing.T) {
@@ -599,30 +656,6 @@ func TestKubeContextAccessor(t *testing.T) {
 			assert.Equal(t, tt.want, New(tt.opts...).KubeContext())
 		})
 	}
-}
-
-// TestClose verifies Close clears the memoized platform config without
-// error, so a subsequent Platform call re-resolves rather than returning a
-// stale cached value.
-func TestClose(t *testing.T) {
-	platformPath := filepath.Join(t.TempDir(), "deployah.platform.yaml")
-	platformYAML := `apiVersion: platform/v1-alpha.3
-environments:
-  production:
-    domains:
-      main:
-        baseDomain: example.com
-`
-	require.NoError(t, writeFile(platformPath, platformYAML))
-
-	sess := New(WithPlatformFile(platformPath))
-
-	_, err := sess.Platform()
-	require.NoError(t, err)
-	require.NotNil(t, sess.platform, "platform should be memoized after first load")
-
-	require.NoError(t, sess.Close())
-	assert.Nil(t, sess.platform, "Close should clear the memoized platform config")
 }
 
 // TestSpec verifies Spec loads a real manifest from disk and wraps load

--- a/internal/workspace/doc.go
+++ b/internal/workspace/doc.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package workspace owns the Deployah project source locations for one
+// invocation and loads the spec and optional platform configuration from
+// those sources.
+//
+// A Workspace does not resolve Kubernetes destinations and does not
+// construct Helm or Kubernetes clients.
+//
+// # Platform source precedence
+//
+// Source selection is snapshotted in [New]:
+//
+//  1. explicit [Config.PlatformPath]
+//  2. DEPLOYAH_PLATFORM_FILE
+//  3. deployah.platform.yaml next to the effective spec
+//
+// An explicit or environment-selected path is required.
+// The default adjacent file is optional: [Workspace.Platform] returns
+// (nil, nil) when it is missing.
+package workspace

--- a/internal/workspace/platform.go
+++ b/internal/workspace/platform.go
@@ -1,0 +1,73 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+
+	"deployah.dev/deployah/internal/spec"
+)
+
+// platformSource is the platform file selected at Workspace construction.
+type platformSource struct {
+	path     string
+	required bool
+}
+
+func selectPlatformSource(explicitPath, specPath string) platformSource {
+	if explicitPath != "" {
+		return platformSource{path: explicitPath, required: true}
+	}
+	if envPath := os.Getenv(spec.PlatformEnvVar); envPath != "" {
+		return platformSource{path: envPath, required: true}
+	}
+	return platformSource{
+		path:     filepath.Join(filepath.Dir(specPath), spec.DefaultPlatformPath),
+		required: false,
+	}
+}
+
+// PlatformPath returns the snapshotted platform file path.
+func (w *Workspace) PlatformPath() string {
+	return w.platformSource.path
+}
+
+// Platform loads and memoizes the platform configuration from the
+// snapshotted source.
+//
+// A successful load is memoized. A missing optional adjacent file returns
+// (nil, nil). A missing or unreadable required source (explicit path or
+// DEPLOYAH_PLATFORM_FILE) returns an error. Failed loads and the optional
+// miss are not cached.
+func (w *Workspace) Platform() (*spec.PlatformConfig, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.platform != nil {
+		return w.platform, nil
+	}
+	path := w.platformSource.path
+	if !w.platformSource.required {
+		if _, err := os.Stat(path); err != nil {
+			return nil, nil //nolint:nilnil // absent optional platform file is not an error; callers check for nil config
+		}
+	}
+	p, err := spec.LoadPlatform(path)
+	if err != nil {
+		return nil, err
+	}
+	w.platform = p
+	return p, nil
+}

--- a/internal/workspace/platform_test.go
+++ b/internal/workspace/platform_test.go
@@ -1,0 +1,192 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"deployah.dev/deployah/internal/spec"
+	"deployah.dev/deployah/internal/workspace"
+)
+
+func TestPlatformPath_ExplicitWinsOverEnvAndAdjacent(t *testing.T) {
+	specPath, adjacentPath := specAndAdjacent(t, minimalSpecYAML, platformYAML("adjacent.example"))
+	explicitPath := filepath.Join(t.TempDir(), "explicit.platform.yaml")
+	envPath := filepath.Join(t.TempDir(), "env.platform.yaml")
+	writeFile(t, explicitPath, platformYAML("explicit.example"))
+	writeFile(t, envPath, platformYAML("env.example"))
+	t.Setenv(spec.PlatformEnvVar, envPath)
+
+	w := workspace.New(workspace.Config{
+		SpecPath:     specPath,
+		PlatformPath: explicitPath,
+	})
+	assert.Equal(t, explicitPath, w.PlatformPath())
+	assert.NotEqual(t, envPath, w.PlatformPath())
+	assert.NotEqual(t, adjacentPath, w.PlatformPath())
+}
+
+func TestPlatformPath_EnvWinsOverAdjacent(t *testing.T) {
+	specPath, adjacentPath := specAndAdjacent(t, minimalSpecYAML, platformYAML("adjacent.example"))
+	envPath := filepath.Join(t.TempDir(), "env.platform.yaml")
+	writeFile(t, envPath, platformYAML("env.example"))
+	t.Setenv(spec.PlatformEnvVar, envPath)
+
+	w := workspace.New(workspace.Config{SpecPath: specPath})
+	assert.Equal(t, envPath, w.PlatformPath())
+	assert.NotEqual(t, adjacentPath, w.PlatformPath())
+}
+
+func TestPlatformPath_AdjacentFallback(t *testing.T) {
+	t.Setenv(spec.PlatformEnvVar, "")
+	specPath := filepath.Join(t.TempDir(), "project", "deployah.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(specPath), 0o700))
+	writeFile(t, specPath, minimalSpecYAML)
+
+	w := workspace.New(workspace.Config{SpecPath: specPath})
+	assert.Equal(t, filepath.Join(filepath.Dir(specPath), spec.DefaultPlatformPath), w.PlatformPath())
+}
+
+func TestPlatformSource_SnapshotsEnvAtConstruction(t *testing.T) {
+	pathA := filepath.Join(t.TempDir(), "a.platform.yaml")
+	pathB := filepath.Join(t.TempDir(), "b.platform.yaml")
+	writeFile(t, pathA, platformYAML("a.example"))
+	writeFile(t, pathB, platformYAML("b.example"))
+
+	t.Setenv(spec.PlatformEnvVar, pathA)
+	w := workspace.New(workspace.Config{})
+	t.Setenv(spec.PlatformEnvVar, pathB)
+
+	assert.Equal(t, pathA, w.PlatformPath())
+	p, err := w.Platform()
+	require.NoError(t, err)
+	requireProductionDomain(t, p, "a.example")
+}
+
+func TestPlatform_ExplicitMissingIsError(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "missing.platform.yaml")
+	w := workspace.New(workspace.Config{PlatformPath: missing})
+	p, err := w.Platform()
+	require.Error(t, err)
+	assert.Nil(t, p)
+	assert.Contains(t, err.Error(), "platform file not found")
+}
+
+func TestPlatform_EnvMissingIsError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing-env.platform.yaml")
+	t.Setenv(spec.PlatformEnvVar, missing)
+
+	w := workspace.New(workspace.Config{})
+	p, err := w.Platform()
+	require.Error(t, err)
+	assert.Nil(t, p)
+	assert.Contains(t, err.Error(), "platform file not found")
+}
+
+func TestPlatform_AdjacentMissingIsOptional(t *testing.T) {
+	t.Setenv(spec.PlatformEnvVar, "")
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	writeFile(t, specPath, minimalSpecYAML)
+
+	w := workspace.New(workspace.Config{SpecPath: specPath})
+	p, err := w.Platform()
+	require.NoError(t, err)
+	assert.Nil(t, p)
+}
+
+func TestPlatform_LoadsExplicitFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "deployah.platform.yaml")
+	writeFile(t, path, platformYAML("explicit.example"))
+	w := workspace.New(workspace.Config{PlatformPath: path})
+	p, err := w.Platform()
+	require.NoError(t, err)
+	requireProductionDomain(t, p, "explicit.example")
+}
+
+func TestPlatform_LoadsEnvSelectedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "env.platform.yaml")
+	writeFile(t, path, platformYAML("env.example"))
+	t.Setenv(spec.PlatformEnvVar, path)
+
+	w := workspace.New(workspace.Config{})
+	p, err := w.Platform()
+	require.NoError(t, err)
+	requireProductionDomain(t, p, "env.example")
+}
+
+func TestPlatform_LoadsAdjacentFile(t *testing.T) {
+	t.Setenv(spec.PlatformEnvVar, "")
+	specPath, _ := specAndAdjacent(t, minimalSpecYAML, platformYAML("adjacent.example"))
+
+	w := workspace.New(workspace.Config{SpecPath: specPath})
+	p, err := w.Platform()
+	require.NoError(t, err)
+	requireProductionDomain(t, p, "adjacent.example")
+}
+
+func TestPlatform_SuccessfulLoadIsMemoized(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "deployah.platform.yaml")
+	writeFile(t, path, platformYAML("cached.example"))
+	w := workspace.New(workspace.Config{PlatformPath: path})
+
+	first, err := w.Platform()
+	require.NoError(t, err)
+	requireProductionDomain(t, first, "cached.example")
+
+	require.NoError(t, os.Remove(path))
+	writeFile(t, path, platformYAML("changed.example"))
+
+	second, err := w.Platform()
+	require.NoError(t, err)
+	assert.Same(t, first, second)
+	requireProductionDomain(t, second, "cached.example")
+}
+
+func TestPlatform_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "deployah.platform.yaml")
+	writeFile(t, path, platformYAML("race.example"))
+	w := workspace.New(workspace.Config{PlatformPath: path})
+
+	const n = 32
+	var got [n]*spec.PlatformConfig
+	var errs [n]error
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Go(func() {
+			got[i], errs[i] = w.Platform()
+		})
+	}
+	wg.Wait()
+
+	for i := range n {
+		require.NoError(t, errs[i])
+		requireProductionDomain(t, got[i], "race.example")
+		assert.Same(t, got[0], got[i])
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,0 +1,90 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"sync"
+
+	"deployah.dev/deployah/internal/spec"
+)
+
+// Config holds source-location inputs for a [Workspace].
+type Config struct {
+	// SpecPath is the Deployah spec file. Empty means [spec.DefaultSpecPath].
+	SpecPath string
+	// PlatformPath is an explicit platform file. Empty means
+	// DEPLOYAH_PLATFORM_FILE, then the default file next to the spec.
+	PlatformPath string
+}
+
+// Workspace owns the Deployah project source locations for one invocation
+// and loads the spec and optional platform configuration from those sources.
+//
+// [New] snapshots the effective spec path and platform source selection,
+// including whether the platform path is required. Later changes to
+// DEPLOYAH_PLATFORM_FILE do not retarget an existing Workspace.
+//
+// Concurrent calls to [Workspace.SpecPath], [Workspace.PlatformPath],
+// [Workspace.Platform], [Workspace.ParseManifest], and [Workspace.LoadSpec]
+// are safe.
+type Workspace struct {
+	specPath       string
+	platformSource platformSource
+	platform       *spec.PlatformConfig
+	mu             sync.Mutex
+}
+
+// New returns a Workspace that snapshots config and the current
+// DEPLOYAH_PLATFORM_FILE value. It does not read the spec or platform files.
+func New(config Config) *Workspace {
+	specPath := cmp.Or(config.SpecPath, spec.DefaultSpecPath)
+	return &Workspace{
+		specPath:       specPath,
+		platformSource: selectPlatformSource(config.PlatformPath, specPath),
+	}
+}
+
+// SpecPath returns the effective spec file path. It is never empty.
+func (w *Workspace) SpecPath() string {
+	return w.specPath
+}
+
+// ParseManifest reads the spec at [Workspace.SpecPath] without envsubst,
+// defaults, or platform resolution.
+func (w *Workspace) ParseManifest() (*spec.Spec, error) {
+	manifest, _, err := spec.ParseManifest(w.specPath)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+// LoadSpec loads the spec for environment from [Workspace.SpecPath] using
+// the Workspace platform and opts. Each call reads the spec from disk
+// because envsubst depends on environment.
+func (w *Workspace) LoadSpec(ctx context.Context, environment string, opts ...spec.LoadOption) (*spec.Spec, error) {
+	platform, err := w.Platform()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load platform file: %w", err)
+	}
+	manifest, err := spec.Load(ctx, w.specPath, environment, platform, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load spec: %w", err)
+	}
+	return manifest, nil
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,263 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"deployah.dev/deployah/internal/spec"
+	"deployah.dev/deployah/internal/workspace"
+)
+
+const minimalSpecYAML = `apiVersion: v1-alpha.5
+project: demo
+components:
+  web:
+    image: nginx:1.27
+    port: 8080
+`
+
+const specWithStagingYAML = `apiVersion: v1-alpha.5
+project: demo
+components:
+  web:
+    image: nginx:1.27
+    port: 8080
+environments:
+  staging: {}
+`
+
+const hookCycleSpecYAML = `apiVersion: v1-alpha.5
+project: shop
+components:
+  api:
+    image: busybox
+    env:
+      LOG_LEVEL: debug
+tasks:
+  migrate:
+    from: api
+    "on": preDeploy
+    after: [seed]
+    command: [migrate]
+  seed:
+    from: api
+    "on": preDeploy
+    after: [migrate]
+    command: [seed]
+environments:
+  staging: {}
+`
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func platformYAML(baseDomain string) string {
+	return `apiVersion: platform/v1-alpha.3
+environments:
+  production:
+    domains:
+      main:
+        baseDomain: ` + baseDomain + `
+`
+}
+
+func requireProductionDomain(t *testing.T, p *spec.PlatformConfig, want string) {
+	t.Helper()
+	require.NotNil(t, p)
+	require.Contains(t, p.Environments, "production")
+	require.Contains(t, p.Environments["production"].Domains, "main")
+	require.Equal(t, want, p.Environments["production"].Domains["main"].BaseDomain)
+}
+
+func specAndAdjacent(t *testing.T, specBody, adjacentBody string) (specPath, adjacentPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	specPath = filepath.Join(dir, "deployah.yaml")
+	adjacentPath = filepath.Join(dir, spec.DefaultPlatformPath)
+	writeFile(t, specPath, specBody)
+	if adjacentBody != "" {
+		writeFile(t, adjacentPath, adjacentBody)
+	}
+	return specPath, adjacentPath
+}
+
+func TestSpecPath_DefaultWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	w := workspace.New(workspace.Config{})
+	assert.Equal(t, spec.DefaultSpecPath, w.SpecPath())
+}
+
+func TestSpecPath_Explicit(t *testing.T) {
+	t.Parallel()
+
+	const path = "/tmp/custom/deployah.yaml"
+	w := workspace.New(workspace.Config{SpecPath: path})
+	assert.Equal(t, path, w.SpecPath())
+}
+
+func TestParseManifest_UsesEffectiveSpecPath(t *testing.T) {
+	t.Parallel()
+
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	writeFile(t, specPath, minimalSpecYAML)
+	w := workspace.New(workspace.Config{SpecPath: specPath})
+
+	got, err := w.ParseManifest()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "demo", got.Project)
+}
+
+func TestParseManifest_DefaultPathInTempDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeFile(t, spec.DefaultSpecPath, minimalSpecYAML)
+
+	w := workspace.New(workspace.Config{})
+	got, err := w.ParseManifest()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "demo", got.Project)
+}
+
+func TestParseManifest_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	w := workspace.New(workspace.Config{
+		SpecPath: filepath.Join(t.TempDir(), "missing.yaml"),
+	})
+	got, err := w.ParseManifest()
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "failed to read spec")
+}
+
+func TestParseManifest_MalformedYAML(t *testing.T) {
+	t.Parallel()
+
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	writeFile(t, specPath, "not: [valid")
+	w := workspace.New(workspace.Config{SpecPath: specPath})
+
+	got, err := w.ParseManifest()
+	require.Error(t, err)
+	assert.Nil(t, got)
+}
+
+func TestLoadSpec_UsesWorkspacePlatform(t *testing.T) {
+	t.Parallel()
+
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	platformPath := filepath.Join(t.TempDir(), "deployah.platform.yaml")
+	writeFile(t, specPath, specWithStagingYAML)
+	writeFile(t, platformPath, platformYAML("platform.example"))
+
+	w := workspace.New(workspace.Config{
+		SpecPath:     specPath,
+		PlatformPath: platformPath,
+	})
+	got, err := w.LoadSpec(t.Context(), "production")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "demo", got.Project)
+}
+
+func TestLoadSpec_OptionalMissingPlatform(t *testing.T) {
+	t.Setenv(spec.PlatformEnvVar, "")
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	writeFile(t, specPath, specWithStagingYAML)
+
+	w := workspace.New(workspace.Config{SpecPath: specPath})
+	got, err := w.LoadSpec(t.Context(), "staging")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "demo", got.Project)
+}
+
+func TestLoadSpec_RequiredPlatformFailure(t *testing.T) {
+	t.Parallel()
+
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	writeFile(t, specPath, specWithStagingYAML)
+	w := workspace.New(workspace.Config{
+		SpecPath:     specPath,
+		PlatformPath: filepath.Join(t.TempDir(), "missing.platform.yaml"),
+	})
+
+	got, err := w.LoadSpec(t.Context(), "staging")
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "failed to load platform file")
+	assert.NotContains(t, err.Error(), "failed to load spec")
+}
+
+func TestLoadSpec_ForwardsLoadOption(t *testing.T) {
+	t.Setenv(spec.PlatformEnvVar, "")
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	writeFile(t, specPath, hookCycleSpecYAML)
+	w := workspace.New(workspace.Config{SpecPath: specPath})
+
+	_, err := w.LoadSpec(t.Context(), "staging")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle")
+
+	got, err := w.LoadSpec(t.Context(), "staging", spec.AllowHookCycleForDisplay())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Contains(t, got.Tasks, "migrate")
+	require.Contains(t, got.Tasks, "seed")
+}
+
+func TestWorkspace_ConcurrentReads(t *testing.T) {
+	t.Parallel()
+
+	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
+	platformPath := filepath.Join(t.TempDir(), "deployah.platform.yaml")
+	writeFile(t, specPath, specWithStagingYAML)
+	writeFile(t, platformPath, platformYAML("race.example"))
+	w := workspace.New(workspace.Config{
+		SpecPath:     specPath,
+		PlatformPath: platformPath,
+	})
+	ctx := t.Context()
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			_ = w.SpecPath()
+			_ = w.PlatformPath()
+			if _, err := w.Platform(); err != nil {
+				t.Errorf("Platform: %v", err)
+			}
+			if _, err := w.ParseManifest(); err != nil {
+				t.Errorf("ParseManifest: %v", err)
+			}
+			if _, err := w.LoadSpec(ctx, "production"); err != nil {
+				t.Errorf("LoadSpec: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- extract spec and platform source loading from Session into `internal/workspace`
- snapshot platform source selection at Workspace construction (`--platform-file` > `DEPLOYAH_PLATFORM_FILE` > adjacent default)
- keep Session as a thin facade; route command raw-manifest loads through `ParseManifest()`

## Related

Follows #122 (`internal/target`).

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `nix run .#lint` / pre-commit clean
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore`
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [x] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [x] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`)
- [x] No secrets or local-only paths in the diff