### PR TITLE
detach cluster clients from session

### DIFF
--- a/internal/cmd/deploy/deploy_flow_test.go
+++ b/internal/cmd/deploy/deploy_flow_test.go
@@ -37,13 +37,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// newClusterWithStub builds a [session.Cluster] whose Kubernetes client is
+// newClusterWithStub builds a Session and Cluster whose Kubernetes client is
 // k8sClient (or errors if k8sClient is nil) and whose Helm client is stub.
-func newClusterWithStub(t *testing.T, stub *stubHelmClient, k8sClient kubernetes.Interface) *session.Cluster {
+func newClusterWithStub(t *testing.T, stub *stubHelmClient, k8sClient kubernetes.Interface) (*session.Session, *session.Cluster) {
 	t.Helper()
 
 	sess := session.New(
-		session.WithHelmFactory(func(*session.Session) (session.HelmClient, error) {
+		session.WithHelmFactory(func(*target.Target, session.HelmConfig) (session.HelmClient, error) {
 			return stub, nil
 		}),
 		session.WithKubernetesFactory(func(*target.Target) (kubernetes.Interface, error) {
@@ -55,7 +55,7 @@ func newClusterWithStub(t *testing.T, stub *stubHelmClient, k8sClient kubernetes
 	)
 	cluster, err := sess.Target(t.Context(), "production")
 	require.NoError(t, err)
-	return cluster
+	return sess, cluster
 }
 
 // assertNever is a placeholder error used by newClusterWithStub when a test
@@ -149,8 +149,7 @@ func TestApplyDeploy_RenderMismatch_AbortsBeforeApply(t *testing.T) {
 		},
 		installErr: nil, // would only matter if InstallApp were (wrongly) called
 	}
-	cluster := newClusterWithStub(t, stub, nil)
-	sess := cluster.Session
+	sess, cluster := newClusterWithStub(t, stub, nil)
 
 	planned := &deployPlan{
 		diff:    &planengine.Plan{},
@@ -317,8 +316,7 @@ func TestApplyCRDsOnly_ReportsSuccessAndReadiness(t *testing.T) {
 		},
 	)
 	stub := &stubHelmClient{}
-	cluster := newClusterWithStub(t, stub, k8sClient)
-	sess := cluster.Session
+	sess, cluster := newClusterWithStub(t, stub, k8sClient)
 	c, _, stdout, stderr := nabatContextWithIO(t)
 	plan := &deployPlan{
 		diff: &planengine.Plan{
@@ -365,7 +363,7 @@ func TestApplyBundleCRDs_RESTConfigError(t *testing.T) {
 	stub := &stubHelmClient{}
 	sess := session.New(
 		session.WithKubeconfig(filepath.Join(t.TempDir(), "missing-kubeconfig")),
-		session.WithHelmFactory(func(*session.Session) (session.HelmClient, error) {
+		session.WithHelmFactory(func(*target.Target, session.HelmConfig) (session.HelmClient, error) {
 			return stub, nil
 		}),
 	)
@@ -387,8 +385,7 @@ func TestApplyDeploy_CallsInstallAfterEmptyCRDs(t *testing.T) {
 	stub := &stubHelmClient{
 		renderResults: []*render.RenderResult{testRenderResult(manifest)},
 	}
-	cluster := newClusterWithStub(t, stub, nil)
-	sess := cluster.Session
+	sess, cluster := newClusterWithStub(t, stub, nil)
 	planned := &deployPlan{
 		diff:    &planengine.Plan{Header: planengine.Header{Release: "web-production", Revision: 1}},
 		result:  testRenderResult(manifest),
@@ -415,8 +412,7 @@ func TestApplyDeploy_PropagatesInstallErrorAfterCRDStep(t *testing.T) {
 		renderResults: []*render.RenderResult{testRenderResult(manifest)},
 		installErr:    errors.New("helm boom"),
 	}
-	cluster := newClusterWithStub(t, stub, nil)
-	sess := cluster.Session
+	sess, cluster := newClusterWithStub(t, stub, nil)
 	planned := &deployPlan{
 		diff:    &planengine.Plan{Header: planengine.Header{Release: "web-production", Revision: 1}},
 		result:  testRenderResult(manifest),
@@ -442,7 +438,7 @@ func TestApplyDeploy_PropagatesCRDApplyError(t *testing.T) {
 	}
 	sess := session.New(
 		session.WithKubeconfig(filepath.Join(t.TempDir(), "missing-kubeconfig")),
-		session.WithHelmFactory(func(*session.Session) (session.HelmClient, error) {
+		session.WithHelmFactory(func(*target.Target, session.HelmConfig) (session.HelmClient, error) {
 			return stub, nil
 		}),
 	)

--- a/internal/cmd/plan/plan_test.go
+++ b/internal/cmd/plan/plan_test.go
@@ -115,7 +115,7 @@ func nabatContext(t *testing.T) (*nabat.Context, *bytes.Buffer) {
 
 // sessionWithStub builds a [session.Session] whose Helm client is stub.
 func sessionWithStub(stub *stubHelmClient) *session.Session {
-	return session.New(session.WithHelmFactory(func(*session.Session) (session.HelmClient, error) {
+	return session.New(session.WithHelmFactory(func(*target.Target, session.HelmConfig) (session.HelmClient, error) {
 		return stub, nil
 	}))
 }
@@ -124,7 +124,7 @@ func sessionWithStub(stub *stubHelmClient) *session.Session {
 // runOnline can exercise API capability checks.
 func sessionWithStubAndK8s(stub *stubHelmClient, k8sClient kubernetes.Interface) *session.Session {
 	return session.New(
-		session.WithHelmFactory(func(*session.Session) (session.HelmClient, error) {
+		session.WithHelmFactory(func(*target.Target, session.HelmConfig) (session.HelmClient, error) {
 			return stub, nil
 		}),
 		session.WithKubernetesFactory(func(*target.Target) (kubernetes.Interface, error) {
@@ -438,7 +438,7 @@ spec:
 	stub := &stubHelmClient{offlineResult: renderResult(deploymentV1)}
 	sess := session.New(
 		session.WithSpecPath(specPath),
-		session.WithHelmFactory(func(*session.Session) (session.HelmClient, error) {
+		session.WithHelmFactory(func(*target.Target, session.HelmConfig) (session.HelmClient, error) {
 			return stub, nil
 		}),
 	)
@@ -461,7 +461,7 @@ func TestRunOffline_LoadExtrasError(t *testing.T) {
 	stub := &stubHelmClient{offlineResult: renderResult(deploymentV1)}
 	sess := session.New(
 		session.WithSpecPath(specPath),
-		session.WithHelmFactory(func(*session.Session) (session.HelmClient, error) {
+		session.WithHelmFactory(func(*target.Target, session.HelmConfig) (session.HelmClient, error) {
 			return stub, nil
 		}),
 	)
@@ -505,7 +505,7 @@ spec:
 	}
 	sess := session.New(
 		session.WithSpecPath(specPath),
-		session.WithHelmFactory(func(*session.Session) (session.HelmClient, error) {
+		session.WithHelmFactory(func(*target.Target, session.HelmConfig) (session.HelmClient, error) {
 			return stub, nil
 		}),
 	)

--- a/internal/session/doc.go
+++ b/internal/session/doc.go
@@ -21,8 +21,9 @@
 //
 // Spec and platform source loading is delegated to [workspace.Workspace].
 // Kubernetes destination resolution is delegated to [target.Resolver]. Call
-// [Session.Target] with the environment name to obtain a [Cluster] that wraps
-// the resolved [target.Target] and lazily constructs Helm and Kubernetes
-// clients. Cluster REST and Kubernetes construction still prefer in-cluster
-// config when present.
+// [Session.Target] with the environment name to obtain a [Cluster] that holds
+// the resolved [target.Target], a [HelmConfig] snapshot, client factories,
+// and lazily constructed Helm and Kubernetes clients. Cluster does not
+// embed [Session]. Cluster REST and Kubernetes construction still prefer
+// in-cluster config when present.
 package session

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -52,9 +53,36 @@ type Session struct {
 	debug         bool
 	timeout       time.Duration
 
-	helmFactory func(*Session) (HelmClient, error)
+	helmFactory HelmFactory
 	k8sFactory  func(*target.Target) (kubernetes.Interface, error)
 }
+
+// HelmConfig holds Helm client-construction inputs that are not destination
+// metadata. Context and namespace come from [target.Target].
+//
+// [Session.Target] snapshots these values onto [Cluster]. Session accessors
+// such as [Session.Timeout] keep reading the Session fields.
+type HelmConfig struct {
+	// KubeconfigPath is an explicit kubeconfig file. Empty means Helm uses
+	// extra paths, then process KUBECONFIG / the default kubeconfig.
+	KubeconfigPath string
+	// ExtraKubeconfigPaths are prepended to Helm's default kubeconfig when
+	// KubeconfigPath is empty. Missing files are tolerated by Helm.
+	ExtraKubeconfigPaths []string
+	// StorageDriver is the Helm storage driver (secret, configmap, or memory).
+	// Empty lets [helm.NewClient] use its default ("secret").
+	StorageDriver string
+	// Debug reports whether temporary chart directories should be kept.
+	Debug bool
+	// Timeout is the Helm operation timeout. Zero lets [helm.NewClient] use
+	// its default (5 minutes). [Session.New] sets [DefaultTimeout] (10
+	// minutes) unless [WithTimeout] overrides it.
+	Timeout time.Duration
+}
+
+// HelmFactory constructs a Helm client for a resolved destination.
+// It must not depend on [Session].
+type HelmFactory func(*target.Target, HelmConfig) (HelmClient, error)
 
 // Option is a functional option for configuring a [Session].
 type Option func(*Session)
@@ -123,7 +151,7 @@ func WithTimeout(timeout time.Duration) Option {
 }
 
 // WithHelmFactory sets a custom Helm client factory, primarily for testing.
-func WithHelmFactory(factory func(*Session) (HelmClient, error)) Option {
+func WithHelmFactory(factory HelmFactory) Option {
 	return func(s *Session) { s.helmFactory = factory }
 }
 
@@ -193,7 +221,22 @@ func (s *Session) Target(ctx context.Context, env string) (*Cluster, error) {
 		}
 	}
 	t := target.NewResolver(s.targetConfig()).Resolve(platformContext)
-	return &Cluster{Session: s, target: t}, nil
+	return &Cluster{
+		target:      t,
+		helmConfig:  s.snapshotHelmConfig(),
+		helmFactory: s.helmFactory,
+		k8sFactory:  s.k8sFactory,
+	}, nil
+}
+
+func (s *Session) snapshotHelmConfig() HelmConfig {
+	return HelmConfig{
+		KubeconfigPath:       s.kubeconfig,
+		ExtraKubeconfigPaths: slices.Clone(s.extraKubeconfigPaths),
+		StorageDriver:        s.storageDriver,
+		Debug:                s.debug,
+		Timeout:              s.timeout,
+	}
 }
 
 func (s *Session) targetConfig() target.Config {
@@ -236,48 +279,31 @@ func (s *Session) DebugKeepTempChart() bool { return s.debug }
 // Timeout returns the configured timeout for Helm operations.
 func (s *Session) Timeout() time.Duration { return s.timeout }
 
-// cloneWithContext returns a shallow copy of s with the given kubeContext
-// applied, clearing any cached clients. Used by Cluster to build clients
-// with the resolved context without mutating the original session.
-// The clone shares the same [workspace.Workspace].
-func (s *Session) cloneWithContext(kubeContext string) *Session {
-	return &Session{
-		workspace:            s.workspace,
-		namespace:            s.namespace,
-		kubeconfig:           s.kubeconfig,
-		kubeContext:          kubeContext,
-		extraKubeconfigPaths: s.extraKubeconfigPaths,
-		storageDriver:        s.storageDriver,
-		debug:                s.debug,
-		timeout:              s.timeout,
-		helmFactory:          s.helmFactory,
-		k8sFactory:           s.k8sFactory,
-	}
-}
-
-// defaultHelmFactory creates a Helm client from session configuration.
-func defaultHelmFactory(s *Session) (HelmClient, error) {
+// defaultHelmFactory creates a Helm client from the resolved destination and
+// Helm runtime configuration. Context and namespace come from t; kubeconfig
+// paths, storage driver, timeout, and debug come from cfg.
+func defaultHelmFactory(t *target.Target, cfg HelmConfig) (HelmClient, error) {
 	var opts []helm.Option
-	if s.namespace != "" {
-		opts = append(opts, helm.WithNamespace(s.namespace))
+	if ns := t.Namespace(); ns != "" {
+		opts = append(opts, helm.WithNamespace(ns))
 	}
-	if s.kubeconfig != "" {
-		opts = append(opts, helm.WithKubeconfig(s.kubeconfig))
+	if cfg.KubeconfigPath != "" {
+		opts = append(opts, helm.WithKubeconfig(cfg.KubeconfigPath))
 	}
-	if s.kubeContext != "" {
-		opts = append(opts, helm.WithKubeContext(s.kubeContext))
+	if kubeContext := t.Context(); kubeContext != "" {
+		opts = append(opts, helm.WithKubeContext(kubeContext))
 	}
-	if len(s.extraKubeconfigPaths) > 0 {
-		opts = append(opts, helm.WithExtraKubeconfigPaths(s.extraKubeconfigPaths...))
+	if len(cfg.ExtraKubeconfigPaths) > 0 {
+		opts = append(opts, helm.WithExtraKubeconfigPaths(cfg.ExtraKubeconfigPaths...))
 	}
-	if s.storageDriver != "" {
-		opts = append(opts, helm.WithStorageDriver(s.storageDriver))
+	if cfg.StorageDriver != "" {
+		opts = append(opts, helm.WithStorageDriver(cfg.StorageDriver))
 	}
-	if s.timeout > 0 {
-		opts = append(opts, helm.WithTimeout(s.timeout))
+	if cfg.Timeout > 0 {
+		opts = append(opts, helm.WithTimeout(cfg.Timeout))
 	}
-	if s.debug {
-		opts = append(opts, helm.WithDebug(s.debug))
+	if cfg.Debug {
+		opts = append(opts, helm.WithDebug(cfg.Debug))
 	}
 	return helm.NewClient(opts...)
 }
@@ -314,12 +340,20 @@ func (s *Session) CurrentKubeContext() string {
 // Cluster is a resolved destination plus lazily-initialized Helm and
 // Kubernetes clients. Obtain one via [Session.Target].
 //
-// Destination metadata is owned by [target.Target]. RESTConfig and the
-// default Kubernetes factory still prefer in-cluster config when present;
-// that mismatch with Target metadata is transitional.
+// Destination metadata is owned by [target.Target]. Helm construction uses
+// [HelmConfig] and [HelmFactory]. Kubernetes construction uses a
+// Target-oriented factory. RESTConfig and the default Kubernetes factory
+// still prefer in-cluster config when present; that mismatch with Target
+// metadata is transitional.
+//
+// Cluster does not embed or depend on [Session]. Concurrent [Cluster.Helm]
+// and [Cluster.Kubernetes] calls are safe.
 type Cluster struct {
-	*Session
-	target *target.Target
+	target     *target.Target
+	helmConfig HelmConfig
+
+	helmFactory HelmFactory
+	k8sFactory  func(*target.Target) (kubernetes.Interface, error)
 
 	helm HelmClient
 	k8s  kubernetes.Interface
@@ -337,15 +371,6 @@ func (cl *Cluster) ContextSource() target.ContextSource {
 // Namespace returns the effective namespace for this destination.
 func (cl *Cluster) Namespace() string { return cl.target.Namespace() }
 
-// sessionForContext returns a shallow Session copy targeted at this
-// cluster's resolved destination, with cached clients cleared. Used by
-// Helm so the factory still receives Session-owned settings.
-func (cl *Cluster) sessionForContext() *Session {
-	tmp := cl.cloneWithContext(cl.target.Context())
-	tmp.namespace = cl.target.Namespace()
-	return tmp
-}
-
 // Helm returns a memoized Helm client targeted at the resolved cluster.
 func (cl *Cluster) Helm() (HelmClient, error) {
 	cl.mu.Lock()
@@ -353,11 +378,10 @@ func (cl *Cluster) Helm() (HelmClient, error) {
 	if cl.helm != nil {
 		return cl.helm, nil
 	}
-	tmp := cl.sessionForContext()
-	c, err := tmp.helmFactory(tmp)
+	c, err := cl.helmFactory(cl.target, cl.helmConfig)
 	if err != nil {
 		return nil, fmt.Errorf("helm client (namespace=%q, kubeconfig=%q): %w",
-			cl.target.Namespace(), cl.kubeconfig, err)
+			cl.target.Namespace(), cl.helmConfig.KubeconfigPath, err)
 	}
 	cl.helm = c
 	return cl.helm, nil

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -191,7 +192,7 @@ func (m *MockHelmClient) RollbackRelease(ctx context.Context, releaseName string
 func TestSessionWithDependencyInjection(t *testing.T) {
 	t.Run("should use injected helm factory via Target", func(t *testing.T) {
 		mockHelm := &MockHelmClient{}
-		sess := New(WithHelmFactory(func(s *Session) (HelmClient, error) {
+		sess := New(WithHelmFactory(func(*target.Target, HelmConfig) (HelmClient, error) {
 			return mockHelm, nil
 		}))
 
@@ -242,7 +243,7 @@ func TestSessionWithDependencyInjection(t *testing.T) {
 		mockHelm := &MockHelmClient{}
 		callCount := 0
 
-		sess := New(WithHelmFactory(func(s *Session) (HelmClient, error) {
+		sess := New(WithHelmFactory(func(*target.Target, HelmConfig) (HelmClient, error) {
 			callCount++
 			return mockHelm, nil
 		}))
@@ -260,8 +261,13 @@ func TestSessionWithDependencyInjection(t *testing.T) {
 
 	t.Run("should handle helm factory errors", func(t *testing.T) {
 		expectedError := errors.New("helm factory error")
-		sess := New(WithHelmFactory(func(s *Session) (HelmClient, error) {
-			return nil, expectedError
+		calls := 0
+		sess := New(WithHelmFactory(func(*target.Target, HelmConfig) (HelmClient, error) {
+			calls++
+			if calls == 1 {
+				return nil, expectedError
+			}
+			return &MockHelmClient{}, nil
 		}))
 
 		cluster, err := sess.Target(t.Context(), "")
@@ -270,7 +276,58 @@ func TestSessionWithDependencyInjection(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, client)
-		assert.Contains(t, err.Error(), "helm client")
+		assert.ErrorIs(t, err, expectedError)
+		assert.ErrorContains(t, err, `helm client (namespace="default", kubeconfig="")`)
+
+		client, err = cluster.Helm()
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("should memoize kubernetes client within a cluster", func(t *testing.T) {
+		fakeCS := fake.NewSimpleClientset()
+		callCount := 0
+		sess := New(WithKubernetesFactory(func(*target.Target) (kubernetes.Interface, error) {
+			callCount++
+			return fakeCS, nil
+		}))
+
+		cluster, err := sess.Target(t.Context(), "")
+		require.NoError(t, err)
+		c1, err1 := cluster.Kubernetes()
+		c2, err2 := cluster.Kubernetes()
+
+		assert.NoError(t, err1)
+		assert.NoError(t, err2)
+		assert.Equal(t, c1, c2)
+		assert.Equal(t, 1, callCount, "factory should be called only once")
+	})
+
+	t.Run("should handle kubernetes factory errors", func(t *testing.T) {
+		expectedError := errors.New("kubernetes factory error")
+		calls := 0
+		sess := New(WithKubernetesFactory(func(*target.Target) (kubernetes.Interface, error) {
+			calls++
+			if calls == 1 {
+				return nil, expectedError
+			}
+			return fake.NewSimpleClientset(), nil
+		}))
+
+		cluster, err := sess.Target(t.Context(), "")
+		require.NoError(t, err)
+		client, err := cluster.Kubernetes()
+
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.ErrorIs(t, err, expectedError)
+		assert.ErrorContains(t, err, "kubernetes client:")
+
+		client, err = cluster.Kubernetes()
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.Equal(t, 2, calls)
 	})
 }
 
@@ -416,9 +473,9 @@ func TestClusterHelmUsesResolvedTarget(t *testing.T) {
 	var gotNS, gotCtx string
 	sess := New(
 		WithKubeconfig(path),
-		WithHelmFactory(func(s *Session) (HelmClient, error) {
-			gotNS = s.namespace
-			gotCtx = s.kubeContext
+		WithHelmFactory(func(tgt *target.Target, _ HelmConfig) (HelmClient, error) {
+			gotNS = tgt.Namespace()
+			gotCtx = tgt.Context()
 			return &MockHelmClient{}, nil
 		}),
 	)
@@ -428,6 +485,263 @@ func TestClusterHelmUsesResolvedTarget(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "payments", gotNS)
 	assert.Equal(t, "production", gotCtx)
+}
+
+func TestClusterHelmFactoryReceivesResolvedDestination(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explicit context", func(t *testing.T) {
+		t.Parallel()
+		var got *target.Target
+		sess := New(
+			WithKubeContext("my-context"),
+			WithHelmFactory(func(tgt *target.Target, _ HelmConfig) (HelmClient, error) {
+				got = tgt
+				return &MockHelmClient{}, nil
+			}),
+		)
+		cluster, err := sess.Target(t.Context(), "")
+		require.NoError(t, err)
+		_, err = cluster.Helm()
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "my-context", cluster.Context())
+		assert.Equal(t, "my-context", got.Context())
+		assert.Equal(t, target.ContextSourceExplicit, cluster.ContextSource())
+		assert.Equal(t, target.ContextSourceExplicit, got.ContextSource())
+	})
+
+	t.Run("platform-selected context", func(t *testing.T) {
+		t.Parallel()
+		platformPath := filepath.Join(t.TempDir(), "deployah.platform.yaml")
+		require.NoError(t, writeFile(platformPath, platformContextYAML("prod-eks")))
+		var got *target.Target
+		sess := New(
+			WithPlatformFile(platformPath),
+			WithHelmFactory(func(tgt *target.Target, _ HelmConfig) (HelmClient, error) {
+				got = tgt
+				return &MockHelmClient{}, nil
+			}),
+		)
+		cluster, err := sess.Target(t.Context(), "production")
+		require.NoError(t, err)
+		_, err = cluster.Helm()
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "prod-eks", cluster.Context())
+		assert.Equal(t, "prod-eks", got.Context())
+		assert.Equal(t, target.ContextSourcePlatform, cluster.ContextSource())
+		assert.Equal(t, target.ContextSourcePlatform, got.ContextSource())
+	})
+
+	t.Run("kubeconfig current-context", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "kubeconfig")
+		require.NoError(t, writeFile(path, minimalKubeconfig))
+		var got *target.Target
+		sess := New(
+			WithKubeconfig(path),
+			WithHelmFactory(func(tgt *target.Target, _ HelmConfig) (HelmClient, error) {
+				got = tgt
+				return &MockHelmClient{}, nil
+			}),
+		)
+		cluster, err := sess.Target(t.Context(), "")
+		require.NoError(t, err)
+		_, err = cluster.Helm()
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "test-context", cluster.Context())
+		assert.Equal(t, "test-context", got.Context())
+		assert.Equal(t, target.ContextSourceKubeconfig, cluster.ContextSource())
+		assert.Equal(t, target.ContextSourceKubeconfig, got.ContextSource())
+	})
+
+	t.Run("explicit namespace", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "kubeconfig")
+		require.NoError(t, writeFile(path, kubeconfigWithNamespace("payments")))
+		var got *target.Target
+		sess := New(
+			WithKubeconfig(path),
+			WithNamespace("custom"),
+			WithHelmFactory(func(tgt *target.Target, _ HelmConfig) (HelmClient, error) {
+				got = tgt
+				return &MockHelmClient{}, nil
+			}),
+		)
+		cluster, err := sess.Target(t.Context(), "")
+		require.NoError(t, err)
+		_, err = cluster.Helm()
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "custom", cluster.Namespace())
+		assert.Equal(t, "custom", got.Namespace())
+	})
+
+	t.Run("kubeconfig context namespace", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "kubeconfig")
+		require.NoError(t, writeFile(path, kubeconfigWithNamespace("payments")))
+		var got *target.Target
+		sess := New(
+			WithKubeconfig(path),
+			WithHelmFactory(func(tgt *target.Target, _ HelmConfig) (HelmClient, error) {
+				got = tgt
+				return &MockHelmClient{}, nil
+			}),
+		)
+		cluster, err := sess.Target(t.Context(), "")
+		require.NoError(t, err)
+		_, err = cluster.Helm()
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "payments", cluster.Namespace())
+		assert.Equal(t, "payments", got.Namespace())
+	})
+}
+
+func TestClusterHelmFactoryDefaultNamespaceFallback(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, writeFile(path, minimalKubeconfig))
+	var got *target.Target
+	sess := New(
+		WithKubeconfig(path),
+		WithHelmFactory(func(tgt *target.Target, _ HelmConfig) (HelmClient, error) {
+			got = tgt
+			return &MockHelmClient{}, nil
+		}),
+	)
+	cluster, err := sess.Target(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "default", cluster.Namespace())
+	_, err = cluster.Helm()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "default", got.Namespace())
+}
+
+func TestClusterHelmConfigSnapshot(t *testing.T) {
+	t.Parallel()
+
+	kubePath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, writeFile(kubePath, minimalKubeconfig))
+	extraPath := filepath.Join(t.TempDir(), "extra-kubeconfig")
+	timeout := 90 * time.Second
+	var got HelmConfig
+	sess := New(
+		WithKubeconfig(kubePath),
+		WithExtraKubeconfigPaths(extraPath),
+		WithStorageDriver(HelmStorageDriverConfigMap),
+		WithDebug(true),
+		WithTimeout(timeout),
+		WithHelmFactory(func(_ *target.Target, cfg HelmConfig) (HelmClient, error) {
+			got = cfg
+			return &MockHelmClient{}, nil
+		}),
+	)
+	cluster, err := sess.Target(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, timeout, sess.Timeout())
+	assert.Equal(t, HelmConfig{
+		KubeconfigPath:       kubePath,
+		ExtraKubeconfigPaths: []string{extraPath},
+		StorageDriver:        HelmStorageDriverConfigMap,
+		Debug:                true,
+		Timeout:              timeout,
+	}, cluster.helmConfig)
+
+	require.NotEmpty(t, sess.extraKubeconfigPaths)
+	sess.extraKubeconfigPaths[0] = "mutated"
+	assert.Equal(t, []string{extraPath}, cluster.helmConfig.ExtraKubeconfigPaths)
+
+	_, err = cluster.Helm()
+	require.NoError(t, err)
+	assert.Equal(t, kubePath, got.KubeconfigPath)
+	assert.Equal(t, []string{extraPath}, got.ExtraKubeconfigPaths)
+	assert.Equal(t, HelmStorageDriverConfigMap, got.StorageDriver)
+	assert.True(t, got.Debug)
+	assert.Equal(t, timeout, got.Timeout)
+}
+
+func TestSessionTargetConstructsCluster(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, writeFile(path, minimalKubeconfig))
+	helmCalls := 0
+	k8sCalls := 0
+	sess := New(
+		WithKubeconfig(path),
+		WithHelmFactory(func(*target.Target, HelmConfig) (HelmClient, error) {
+			helmCalls++
+			return &MockHelmClient{}, nil
+		}),
+		WithKubernetesFactory(func(*target.Target) (kubernetes.Interface, error) {
+			k8sCalls++
+			return fake.NewSimpleClientset(), nil
+		}),
+	)
+	cluster, err := sess.Target(t.Context(), "")
+	require.NoError(t, err)
+	require.NotNil(t, cluster.target)
+	assert.Equal(t, "test-context", cluster.Context())
+	assert.Equal(t, path, cluster.helmConfig.KubeconfigPath)
+	assert.NotNil(t, cluster.helmFactory)
+	assert.NotNil(t, cluster.k8sFactory)
+	assert.Nil(t, cluster.helm)
+	assert.Nil(t, cluster.k8s)
+
+	_, err = cluster.Helm()
+	require.NoError(t, err)
+	_, err = cluster.Kubernetes()
+	require.NoError(t, err)
+	assert.Equal(t, 1, helmCalls)
+	assert.Equal(t, 1, k8sCalls)
+}
+
+func TestClusterClientsConcurrent(t *testing.T) {
+	t.Parallel()
+
+	mockHelm := &MockHelmClient{}
+	fakeCS := fake.NewSimpleClientset()
+	sess := New(
+		WithHelmFactory(func(*target.Target, HelmConfig) (HelmClient, error) {
+			return mockHelm, nil
+		}),
+		WithKubernetesFactory(func(*target.Target) (kubernetes.Interface, error) {
+			return fakeCS, nil
+		}),
+	)
+	cluster, err := sess.Target(t.Context(), "")
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			c, herr := cluster.Helm()
+			if herr != nil {
+				t.Errorf("Helm() error: %v", herr)
+				return
+			}
+			if c != mockHelm {
+				t.Errorf("Helm() client mismatch")
+			}
+		})
+		wg.Go(func() {
+			cs, kerr := cluster.Kubernetes()
+			if kerr != nil {
+				t.Errorf("Kubernetes() error: %v", kerr)
+				return
+			}
+			if cs != fakeCS {
+				t.Errorf("Kubernetes() client mismatch")
+			}
+		})
+	}
+	wg.Wait()
 }
 
 func platformContextYAML(contextName string) string {
@@ -615,24 +929,6 @@ func TestSessionPlatformMemoized(t *testing.T) {
 	second, err := sess.Platform()
 	require.NoError(t, err)
 	assert.Same(t, first, second)
-}
-
-func TestCloneWithContextSharesWorkspace(t *testing.T) {
-	pathA := filepath.Join(t.TempDir(), "a.platform.yaml")
-	pathB := filepath.Join(t.TempDir(), "b.platform.yaml")
-	require.NoError(t, writeFile(pathA, platformContextYAML("context-a")))
-	require.NoError(t, writeFile(pathB, platformContextYAML("context-b")))
-
-	t.Setenv(spec.PlatformEnvVar, pathA)
-	sess := New()
-	clone := sess.cloneWithContext("other")
-	assert.Same(t, sess.workspace, clone.workspace)
-
-	t.Setenv(spec.PlatformEnvVar, pathB)
-	assert.Equal(t, pathA, clone.PlatformPath())
-	p, err := clone.Platform()
-	require.NoError(t, err)
-	assert.Equal(t, "context-a", spec.PlatformEnvContext(p, "production"))
 }
 
 // TestKubeContextAccessor verifies KubeContext returns the explicit
@@ -877,7 +1173,7 @@ func TestIntegrationWithMocks(t *testing.T) {
 		mockHelm := &MockHelmClient{}
 		mockHelm.On("InstallApp", mock.Anything, false, mock.Anything, mock.Anything).Return(nil)
 
-		sess := New(WithHelmFactory(func(s *Session) (HelmClient, error) {
+		sess := New(WithHelmFactory(func(*target.Target, HelmConfig) (HelmClient, error) {
 			return mockHelm, nil
 		}))
 


### PR DESCRIPTION
## Summary

- build Cluster from Target, HelmConfig, and client factories instead of embedding Session
- construct Helm from destination metadata plus a HelmConfig snapshot
- keep Session as the command facade (timeout, debug, kube context, spec/platform)

## Related

Follows #123 (`internal/workspace`) and #122 (`internal/target`).

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `nix run .#lint` / pre-commit clean
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore`
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [x] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [x] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`)
- [x] No secrets or local-only paths in the diff