### PR TITLE
expose workspace from session

### DIFF
--- a/internal/cmd/cmdopts/doc.go
+++ b/internal/cmd/cmdopts/doc.go
@@ -17,4 +17,5 @@
 // [GlobalOptions] captures persistent CLI flags such as namespace, kubeconfig,
 // spec path, debug mode, and operation timeout. The root command reads
 // these values in its pre-run hook and builds a [session.Session] from them.
+// Commands load spec and platform sources through [session.Session.Workspace].
 package cmdopts

--- a/internal/cmd/delete/delete.go
+++ b/internal/cmd/delete/delete.go
@@ -113,7 +113,7 @@ func runDelete(c *nabat.Context) error {
 	// active. Without the platform file the delete targets the kubeconfig's
 	// default context, which may be the wrong cluster.
 	if !opts.AllowMissingPlatform {
-		platform, platformErr := rt.Platform()
+		platform, platformErr := rt.Workspace().Platform()
 		if platformErr != nil {
 			return fmt.Errorf("load platform file: %w", platformErr)
 		}

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -89,10 +89,11 @@ func runDeploy(c *nabat.Context) error {
 	c.Logger().Debug("starting deployment process")
 
 	sess := session.FromContext(c)
+	ws := sess.Workspace()
 
 	// Prescan the raw (pre-envsubst) manifest for ${VAR} tokens so the
 	// resolver can distinguish static from dynamic subdomains.
-	rawSpec, rawErr := sess.ParseManifest()
+	rawSpec, rawErr := ws.ParseManifest()
 	if rawErr != nil {
 		return fmt.Errorf("parse manifest: %w", rawErr)
 	}
@@ -100,13 +101,13 @@ func runDeploy(c *nabat.Context) error {
 
 	// The platform file owns the environment registry --environment is
 	// validated against, so it loads before the spec.
-	platform, platformErr := sess.Platform()
+	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		return fmt.Errorf("load platform file: %w", platformErr)
 	}
 
 	// Load the fully substituted manifest (envsubst applied).
-	manifest, err := spec.Load(c, sess.SpecPath(), opts.Environment, platform)
+	manifest, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}
@@ -192,7 +193,7 @@ func runDeploy(c *nabat.Context) error {
 	if restErr != nil {
 		c.Logger().Debug("rest config unavailable for extras scope discovery", "err", restErr)
 	}
-	bundle, err := extras.LoadFromSpec(sess.SpecPath(), manifest, platform, opts.Environment, cluster.Namespace(), restCfg)
+	bundle, err := extras.LoadFromSpec(ws.SpecPath(), manifest, platform, opts.Environment, cluster.Namespace(), restCfg)
 	if err != nil {
 		return fmt.Errorf("load extras: %w", err)
 	}

--- a/internal/cmd/initialize/init.go
+++ b/internal/cmd/initialize/init.go
@@ -82,8 +82,8 @@ func runInit(c *nabat.Context) error {
 
 	c.Logger().Debug("starting project initialization")
 
-	sess := session.FromContext(c)
-	specPath, platformPath := sess.SpecPath(), sess.PlatformPath()
+	ws := session.FromContext(c).Workspace()
+	specPath, platformPath := ws.SpecPath(), ws.PlatformPath()
 
 	proceed, overwriteErr := checkOverwrite(c, specPath, opts.DryRun || opts.Force)
 	if overwriteErr != nil {

--- a/internal/cmd/plan/plan.go
+++ b/internal/cmd/plan/plan.go
@@ -114,22 +114,23 @@ func runPlan(c *nabat.Context) error {
 		return fmt.Errorf("binding options: %w", err)
 	}
 	sess := session.FromContext(c)
+	ws := sess.Workspace()
 
 	// Prescan the raw (pre-envsubst) manifest for ${VAR} tokens so the
 	// resolver can distinguish static from dynamic subdomains, matching
 	// deploy's resolution behavior.
-	rawSpec, rawErr := sess.ParseManifest()
+	rawSpec, rawErr := ws.ParseManifest()
 	if rawErr != nil {
 		return fmt.Errorf("parse manifest: %w", rawErr)
 	}
 	substReport := spec.PrescanSubstitutionReport(rawSpec)
 
-	platform, platformErr := sess.Platform()
+	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		return fmt.Errorf("load platform file: %w", platformErr)
 	}
 
-	manifest, err := spec.Load(c, sess.SpecPath(), opts.Environment, platform)
+	manifest, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}
@@ -180,7 +181,7 @@ func runOffline(c *nabat.Context, sess *session.Session, platform *spec.Platform
 		}
 	}
 
-	bundle, err := extras.LoadFromSpec(sess.SpecPath(), manifest, platform, opts.Environment, cluster.Namespace(), nil)
+	bundle, err := extras.LoadFromSpec(sess.Workspace().SpecPath(), manifest, platform, opts.Environment, cluster.Namespace(), nil)
 	if err != nil {
 		return fmt.Errorf("load extras: %w", err)
 	}
@@ -243,7 +244,7 @@ func runOnline(c *nabat.Context, sess *session.Session, platform *spec.PlatformC
 	if restErr != nil {
 		c.Logger().Debug("rest config unavailable for extras scope discovery", "err", restErr)
 	}
-	bundle, err := extras.LoadFromSpec(sess.SpecPath(), manifest, platform, opts.Environment, cluster.Namespace(), restCfg)
+	bundle, err := extras.LoadFromSpec(sess.Workspace().SpecPath(), manifest, platform, opts.Environment, cluster.Namespace(), restCfg)
 	if err != nil {
 		return fmt.Errorf("load extras: %w", err)
 	}

--- a/internal/cmd/resolve/resolve.go
+++ b/internal/cmd/resolve/resolve.go
@@ -80,6 +80,7 @@ func runResolve(c *nabat.Context) error {
 	}
 
 	sess := session.FromContext(c)
+	ws := sess.Workspace()
 
 	if opts.Environments {
 		return runEnvironmentsOverview(c, sess, opts.Output)
@@ -90,13 +91,13 @@ func runResolve(c *nabat.Context) error {
 
 	// Raw manifest is only for the substitution prescan. Resolution must
 	// see the substituted spec so ${...} in env and envFile match deploy.
-	rawSpec, err := sess.ParseManifest()
+	rawSpec, err := ws.ParseManifest()
 	if err != nil {
 		return fmt.Errorf("load manifest: %w", err)
 	}
 
 	// Load platform (degraded when absent). It owns the environment registry.
-	platform, platformErr := sess.Platform()
+	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		// Platform file was found but failed to load: hard error.
 		return fmt.Errorf("load platform: %w", platformErr)
@@ -109,7 +110,7 @@ func runResolve(c *nabat.Context) error {
 
 	substReport := spec.PrescanSubstitutionReport(rawSpec)
 
-	manifest, err := spec.Load(c, sess.SpecPath(), opts.Environment, platform, spec.AllowHookCycleForDisplay())
+	manifest, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform, spec.AllowHookCycleForDisplay())
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}
@@ -365,11 +366,12 @@ func buildEnvironmentOverview(rawSpec *spec.Spec, platform *spec.PlatformConfig,
 // runEnvironmentsOverview prints every environment from the spec and
 // platform files in the requested output format.
 func runEnvironmentsOverview(c *nabat.Context, sess *session.Session, output string) error {
-	rawSpec, err := sess.ParseManifest()
+	ws := sess.Workspace()
+	rawSpec, err := ws.ParseManifest()
 	if err != nil {
 		return fmt.Errorf("load manifest: %w", err)
 	}
-	platform, platformErr := sess.Platform()
+	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		return fmt.Errorf("load platform: %w", platformErr)
 	}

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -79,13 +79,14 @@ func runTask(c *nabat.Context) error {
 	}
 
 	sess := session.FromContext(c)
+	ws := sess.Workspace()
 
-	platform, platformErr := sess.Platform()
+	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		return fmt.Errorf("load platform file: %w", platformErr)
 	}
 
-	manifest, err := spec.Load(c, sess.SpecPath(), opts.Environment, platform)
+	manifest, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}

--- a/internal/cmd/validate/validate.go
+++ b/internal/cmd/validate/validate.go
@@ -10,6 +10,7 @@ import (
 
 	"deployah.dev/deployah/internal/session"
 	"deployah.dev/deployah/internal/spec"
+	"deployah.dev/deployah/internal/workspace"
 )
 
 // Options holds command-line flags for validate.
@@ -46,19 +47,19 @@ func runValidate(c *nabat.Context) error {
 		return fmt.Errorf("binding options: %w", err)
 	}
 
-	rt := session.FromContext(c)
+	ws := session.FromContext(c).Workspace()
 
 	if opts.Environment == "" {
-		return runManifestOnly(c, rt)
+		return runManifestOnly(c, ws)
 	}
-	return runCrossFile(c, rt, opts.Environment)
+	return runCrossFile(c, ws, opts.Environment)
 }
 
 // runManifestOnly validates only the manifest schema without environment
 // resolution. It applies type-aware sentinel substitution so ${VAR} tokens
 // do not cause false format-assertion failures, while literal typos still fail.
-func runManifestOnly(c *nabat.Context, rt *session.Session) error {
-	specPath := rt.SpecPath()
+func runManifestOnly(c *nabat.Context, ws *workspace.Workspace) error {
+	specPath := ws.SpecPath()
 	data, err := os.ReadFile(specPath) // #nosec G304
 	if err != nil {
 		return fmt.Errorf("failed to read manifest: %w", err)
@@ -89,7 +90,7 @@ func runManifestOnly(c *nabat.Context, rt *session.Session) error {
 	// Cross-field and platform checks are best-effort here: they need the
 	// raw (pre-substitution) spec, so a manifest that only unmarshals after
 	// ${VAR} substitution skips them with a warning.
-	rawSpec, parseErr := rt.ParseManifest()
+	rawSpec, parseErr := ws.ParseManifest()
 	if parseErr != nil {
 		c.Warn(fmt.Sprintf("skipping cross-field checks: %v", parseErr))
 	} else {
@@ -99,7 +100,7 @@ func runManifestOnly(c *nabat.Context, rt *session.Session) error {
 		if taskErr := spec.ValidateSpecTasks(rawSpec, false); taskErr != nil {
 			return taskErr
 		}
-		platform, platformErr := rt.Platform()
+		platform, platformErr := ws.Platform()
 		if platformErr != nil {
 			return fmt.Errorf("platform file error: %w", platformErr)
 		}
@@ -123,20 +124,20 @@ func runManifestOnly(c *nabat.Context, rt *session.Session) error {
 // runCrossFile validates the substituted spec and runs [spec.Resolve] for
 // the named environment. A missing platform file is allowed when the spec
 // does not use platform-owned features.
-func runCrossFile(c *nabat.Context, rt *session.Session, environment string) error {
-	rawSpec, err := rt.ParseManifest()
+func runCrossFile(c *nabat.Context, ws *workspace.Workspace, environment string) error {
+	rawSpec, err := ws.ParseManifest()
 	if err != nil {
 		return fmt.Errorf("manifest invalid: %w", err)
 	}
 
-	platform, platformErr := rt.Platform()
+	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		return fmt.Errorf("platform file error: %w", platformErr)
 	}
 
 	substReport := spec.PrescanSubstitutionReport(rawSpec)
 
-	loaded, err := spec.Load(c, rt.SpecPath(), environment, platform)
+	loaded, err := spec.Load(c, ws.SpecPath(), environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}

--- a/internal/session/doc.go
+++ b/internal/session/doc.go
@@ -14,16 +14,17 @@
 
 // Package session holds per-command Kubernetes and Helm client state.
 //
-// [Session] carries the global CLI options (kubeconfig, namespace, spec path,
-// etc.) and travels through [context.Context] so every command shares one
-// configured environment per invocation. Construct one with [New], attach it
-// via [WithContext], and retrieve it in handlers through [FromContext].
+// [Session] is the invocation handle for one CLI run. It carries global
+// options and travels through [context.Context] so every command shares one
+// configured environment. Construct one with [New], attach it via
+// [WithContext], and retrieve it in handlers through [FromContext].
 //
-// Spec and platform source loading is delegated to [workspace.Workspace].
-// Kubernetes destination resolution is delegated to [target.Resolver]. Call
-// [Session.Target] with the environment name to obtain a [Cluster] that holds
-// the resolved [target.Target], a [HelmConfig] snapshot, client factories,
-// and lazily constructed Helm and Kubernetes clients. Cluster does not
-// embed [Session]. Cluster REST and Kubernetes construction still prefer
+// Spec and platform source loading is owned by [workspace.Workspace].
+// Call [Session.Workspace] to load those sources. Kubernetes destination
+// resolution is delegated to [target.Resolver]. Call [Session.Target] with
+// the environment name to obtain a [Cluster] that holds the resolved
+// [target.Target], a [HelmConfig] snapshot, client factories, and lazily
+// constructed Helm and Kubernetes clients. Cluster does not embed
+// [Session]. Cluster REST and Kubernetes construction still prefer
 // in-cluster config when present.
 package session

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -19,26 +19,14 @@ import (
 // sessionKey is a private context key for storing the Session in context.
 type sessionKey struct{}
 
-// CommandPolicy controls how the session handles missing platform files.
-type CommandPolicy int
-
-const (
-	// PolicyLenient allows proceeding with a warning when the platform file
-	// is absent. Used for read-only commands (logs, status, list, shell).
-	PolicyLenient CommandPolicy = iota
-	// PolicyStrict requires a resolvable platform file for commands that
-	// modify cluster state (deploy, delete). The caller must gate on this
-	// before contacting the cluster.
-	PolicyStrict
-)
-
-// Session holds per-invocation configuration and lazily loads the spec.
+// Session holds per-invocation configuration for one CLI run.
 // It is created once in the root pre-run hook and travels through
 // [context.Context] so every command shares one configured environment.
 //
-// Spec and platform source loading is delegated to [workspace.Workspace].
-// Kubernetes destination resolution is delegated to [target.Resolver].
-// To access Helm or Kubernetes clients, call [Session.Target] first.
+// Spec and platform source loading is owned by [workspace.Workspace].
+// Call [Session.Workspace] to load sources. Kubernetes destination
+// resolution is delegated to [target.Resolver]. To access Helm or
+// Kubernetes clients, call [Session.Target] first.
 type Session struct {
 	workspaceConfig workspace.Config
 	workspace       *workspace.Workspace
@@ -47,7 +35,6 @@ type Session struct {
 	kubeconfig           string
 	kubeContext          string
 	extraKubeconfigPaths []string
-	commandPolicy        CommandPolicy
 
 	storageDriver string
 	debug         bool
@@ -125,16 +112,6 @@ func WithPlatformFile(path string) Option {
 	return func(s *Session) { s.workspaceConfig.PlatformPath = path }
 }
 
-// WithCommandPolicy sets the platform-missing policy for this session.
-// Destructive commands (deploy, delete) should use [PolicyStrict];
-// read-only commands (logs, status, list, shell) should use [PolicyLenient].
-func WithCommandPolicy(policy CommandPolicy) Option {
-	return func(s *Session) { s.commandPolicy = policy }
-}
-
-// CommandPolicy returns the configured platform-missing policy.
-func (s *Session) CommandPolicy() CommandPolicy { return s.commandPolicy }
-
 // WithStorageDriver sets the Helm storage driver (default: "secret").
 func WithStorageDriver(driver string) Option {
 	return func(s *Session) { s.storageDriver = driver }
@@ -192,19 +169,11 @@ func FromContext(ctx context.Context) *Session {
 	return nil
 }
 
-// Platform loads and memoizes the platform configuration through the
-// composed [workspace.Workspace]. See [workspace.Workspace.Platform] for
-// required versus optional source semantics.
-func (s *Session) Platform() (*spec.PlatformConfig, error) {
-	return s.workspace.Platform()
-}
-
-// Spec loads the spec for [Session.SpecPath] and environment. Each call loads
-// from disk because the result depends on the environment argument (envsubst
-// selects different env files per environment). The platform config, when
-// present, supplies the environment registry.
-func (s *Session) Spec(ctx context.Context, environment string) (*spec.Spec, error) {
-	return s.workspace.LoadSpec(ctx, environment)
+// Workspace returns the invocation [workspace.Workspace] that owns spec
+// and platform source locations. The Workspace is created in [New] and
+// does not change for the rest of the Session.
+func (s *Session) Workspace() *workspace.Workspace {
+	return s.workspace
 }
 
 // Target resolves the Kubernetes destination for env and returns a [Cluster]
@@ -212,11 +181,12 @@ func (s *Session) Spec(ctx context.Context, environment string) (*spec.Spec, err
 //
 // Destination resolution is delegated to [target.Resolver]. The platform
 // file, when present, supplies only a context name via
-// [spec.PlatformEnvContext]. ctx is unused.
+// [spec.PlatformEnvContext]. Platform load errors are ignored so Target
+// can still resolve from kubeconfig. ctx is unused.
 func (s *Session) Target(ctx context.Context, env string) (*Cluster, error) {
 	platformContext := ""
 	if env != "" {
-		if p, err := s.Platform(); err == nil && p != nil {
+		if p, err := s.workspace.Platform(); err == nil && p != nil {
 			platformContext = spec.PlatformEnvContext(p, env)
 		}
 	}
@@ -248,33 +218,10 @@ func (s *Session) targetConfig() target.Config {
 	}
 }
 
-// SpecPath returns the effective spec file path from the composed Workspace.
-// The path is never empty; an unset option defaults to [spec.DefaultSpecPath].
-func (s *Session) SpecPath() string {
-	return s.workspace.SpecPath()
-}
-
-// PlatformPath returns the snapshotted platform file path from the
-// composed Workspace.
-func (s *Session) PlatformPath() string {
-	return s.workspace.PlatformPath()
-}
-
-// ParseManifest reads and partially validates the spec (apiVersion +
-// environments only, no envsubst, no defaults). It is intended for commands
-// that need the raw manifest structure without environment-specific processing
-// (e.g. validate manifest-only mode, substitution prescan).
-func (s *Session) ParseManifest() (*spec.Spec, error) {
-	return s.workspace.ParseManifest()
-}
-
 // KubeContext returns the explicit kube context override, or empty string if
 // none was set. An empty string means the cluster context comes from the
 // platform file or kubeconfig default.
 func (s *Session) KubeContext() string { return s.kubeContext }
-
-// DebugKeepTempChart reports whether temporary chart directories should be kept.
-func (s *Session) DebugKeepTempChart() bool { return s.debug }
 
 // Timeout returns the configured timeout for Helm operations.
 func (s *Session) Timeout() time.Duration { return s.timeout }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -61,16 +61,6 @@ users:
     token: fake-token
 `
 
-// minimalSpecYAML is a self-contained spec fixture with a valid apiVersion
-// and a single component, reused by Spec/ParseManifest tests.
-const minimalSpecYAML = `apiVersion: v1-alpha.5
-project: demo
-components:
-  web:
-    image: nginx:1.27
-    port: 8080
-`
-
 // MockHelmClient is a mock implementation of [HelmClient] for testing.
 type MockHelmClient struct {
 	mock.Mock
@@ -464,6 +454,25 @@ func TestTarget(t *testing.T) {
 	})
 }
 
+func TestSessionTargetIgnoresPlatformError(t *testing.T) {
+	t.Parallel()
+
+	kubePath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, writeFile(kubePath, minimalKubeconfig))
+	missingPlatform := filepath.Join(t.TempDir(), "missing.platform.yaml")
+	sess := New(
+		WithKubeconfig(kubePath),
+		WithPlatformFile(missingPlatform),
+	)
+	_, platErr := sess.Workspace().Platform()
+	require.ErrorContains(t, platErr, "platform file not found: "+missingPlatform)
+
+	cluster, err := sess.Target(t.Context(), "production")
+	require.NoError(t, err)
+	assert.Equal(t, "test-context", cluster.Context())
+	assert.Equal(t, target.ContextSourceKubeconfig, cluster.ContextSource())
+}
+
 func TestClusterHelmUsesResolvedTarget(t *testing.T) {
 	t.Parallel()
 
@@ -780,53 +789,6 @@ func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o600)
 }
 
-// TestCommandPolicy verifies the WithCommandPolicy option round-trips
-// through the CommandPolicy accessor, including the unset default.
-func TestCommandPolicy(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		opts []Option
-		want CommandPolicy
-	}{
-		{name: "defaults to lenient when unset", want: PolicyLenient},
-		{name: "strict policy round-trips", opts: []Option{WithCommandPolicy(PolicyStrict)}, want: PolicyStrict},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.want, New(tt.opts...).CommandPolicy())
-		})
-	}
-}
-
-// TestDebugKeepTempChart verifies the WithDebug option round-trips through
-// the DebugKeepTempChart accessor.
-func TestDebugKeepTempChart(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		opts []Option
-		want bool
-	}{
-		{name: "defaults to false when unset", want: false},
-		{name: "true round-trips", opts: []Option{WithDebug(true)}, want: true},
-		{name: "explicit false round-trips", opts: []Option{WithDebug(false)}, want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.want, New(tt.opts...).DebugKeepTempChart())
-		})
-	}
-}
-
 // TestTimeoutAccessor verifies the Timeout accessor returns the configured
 // value, including the package default when unset.
 func TestTimeoutAccessor(t *testing.T) {
@@ -850,85 +812,23 @@ func TestTimeoutAccessor(t *testing.T) {
 	}
 }
 
-// TestSpecPathAccessor verifies SpecPath returns the configured spec path,
-// or [spec.DefaultSpecPath] when unset.
-func TestSpecPathAccessor(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		opts []Option
-		want string
-	}{
-		{name: "default filename when unset", want: spec.DefaultSpecPath},
-		{name: "returns configured path", opts: []Option{WithSpecPath("/tmp/deployah.yaml")}, want: "/tmp/deployah.yaml"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.want, New(tt.opts...).SpecPath())
-		})
-	}
-}
-
-func TestPlatformPathAccessor(t *testing.T) {
-	tests := []struct {
-		name string
-		opts []Option
-		want string
-	}{
-		{name: "default filename when unset", want: spec.DefaultPlatformPath},
-		{name: "explicit platform file", opts: []Option{WithPlatformFile("/tmp/custom.platform.yaml")}, want: "/tmp/custom.platform.yaml"},
-		{name: "same directory as spec", opts: []Option{WithSpecPath(filepath.Join("app", "deployah.yaml"))}, want: filepath.Join("app", spec.DefaultPlatformPath)},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(spec.PlatformEnvVar, "")
-			assert.Equal(t, tt.want, New(tt.opts...).PlatformPath())
-		})
-	}
-}
-
 func TestSessionConstructsWorkspaceAfterOptions(t *testing.T) {
 	t.Parallel()
 
 	specPath := filepath.Join(t.TempDir(), "deployah.yaml")
 	platformPath := filepath.Join(t.TempDir(), "custom.platform.yaml")
 	sess := New(WithSpecPath(specPath), WithPlatformFile(platformPath))
-	assert.Equal(t, specPath, sess.SpecPath())
-	assert.Equal(t, platformPath, sess.PlatformPath())
+	ws := sess.Workspace()
+	require.NotNil(t, ws)
+	assert.Equal(t, specPath, ws.SpecPath())
+	assert.Equal(t, platformPath, ws.PlatformPath())
 }
 
-func TestSessionPlatformDelegation(t *testing.T) {
+func TestSessionWorkspaceReturnsSameInstance(t *testing.T) {
 	t.Parallel()
 
-	platformPath := filepath.Join(t.TempDir(), "deployah.platform.yaml")
-	require.NoError(t, writeFile(platformPath, platformContextYAML("prod-eks")))
-	sess := New(WithPlatformFile(platformPath))
-	p, err := sess.Platform()
-	require.NoError(t, err)
-	require.NotNil(t, p)
-	assert.Equal(t, "prod-eks", spec.PlatformEnvContext(p, "production"))
-}
-
-func TestSessionPlatformMemoized(t *testing.T) {
-	t.Parallel()
-
-	platformPath := filepath.Join(t.TempDir(), "deployah.platform.yaml")
-	require.NoError(t, writeFile(platformPath, platformContextYAML("prod-eks")))
-	sess := New(WithPlatformFile(platformPath))
-
-	first, err := sess.Platform()
-	require.NoError(t, err)
-	require.NotNil(t, first)
-
-	require.NoError(t, os.Remove(platformPath))
-	second, err := sess.Platform()
-	require.NoError(t, err)
-	assert.Same(t, first, second)
+	sess := New()
+	assert.Same(t, sess.Workspace(), sess.Workspace())
 }
 
 // TestKubeContextAccessor verifies KubeContext returns the explicit
@@ -950,111 +850,6 @@ func TestKubeContextAccessor(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(t, tt.want, New(tt.opts...).KubeContext())
-		})
-	}
-}
-
-// TestSpec verifies Spec loads a real manifest from disk and wraps load
-// errors when the file is missing.
-func TestSpec(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		setup       func(t *testing.T) *Session
-		wantErr     bool
-		errContains string
-		check       func(t *testing.T, m *spec.Spec)
-	}{
-		{
-			name: "loads a valid manifest from disk",
-			setup: func(t *testing.T) *Session {
-				t.Helper()
-				specPath := filepath.Join(t.TempDir(), "deployah.yaml")
-				require.NoError(t, writeFile(specPath, minimalSpecYAML))
-				return New(WithSpecPath(specPath))
-			},
-			check: func(t *testing.T, m *spec.Spec) {
-				t.Helper()
-				require.NotNil(t, m)
-				assert.Equal(t, "demo", m.Project)
-			},
-		},
-		{
-			name: "wraps the underlying load error for a missing file",
-			setup: func(t *testing.T) *Session {
-				t.Helper()
-				return New(WithSpecPath(filepath.Join(t.TempDir(), "missing.yaml")))
-			},
-			wantErr:     true,
-			errContains: "failed to load spec",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			m, err := tt.setup(t).Spec(t.Context(), "")
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, m)
-				assert.Contains(t, err.Error(), tt.errContains)
-				return
-			}
-			require.NoError(t, err)
-			tt.check(t, m)
-		})
-	}
-}
-
-// TestParseManifest verifies ParseManifest's happy path and its behavior
-// when the underlying file cannot be read.
-func TestParseManifest(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		setup   func(t *testing.T) *Session
-		wantErr bool
-		check   func(t *testing.T, m *spec.Spec)
-	}{
-		{
-			name: "parses a valid manifest",
-			setup: func(t *testing.T) *Session {
-				t.Helper()
-				specPath := filepath.Join(t.TempDir(), "deployah.yaml")
-				require.NoError(t, writeFile(specPath, minimalSpecYAML))
-				return New(WithSpecPath(specPath))
-			},
-			check: func(t *testing.T, m *spec.Spec) {
-				t.Helper()
-				require.NotNil(t, m)
-				assert.Equal(t, "demo", m.Project)
-			},
-		},
-		{
-			name: "errors for a missing file",
-			setup: func(t *testing.T) *Session {
-				t.Helper()
-				return New(WithSpecPath(filepath.Join(t.TempDir(), "missing.yaml")))
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			m, err := tt.setup(t).ParseManifest()
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, m)
-				return
-			}
-			require.NoError(t, err)
-			tt.check(t, m)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- add `Session.Workspace()` and route command spec/platform loads through it
- remove unused Session source facades, `Spec`, `CommandPolicy`, and `DebugKeepTempChart`
- keep `Session.Target` as cluster orchestration (platform load errors still ignored)

## Related

Follows #124 (Cluster), #123 (`internal/workspace`), and #122 (`internal/target`).

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `nix run .#lint` / pre-commit clean
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore`
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [x] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [x] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`)
- [x] No secrets or local-only paths in the diff