### PR TITLE
remove implicit in-cluster dest

### DIFF
--- a/internal/session/doc.go
+++ b/internal/session/doc.go
@@ -25,6 +25,6 @@
 // the environment name to obtain a [Cluster] that holds the resolved
 // [target.Target], a [HelmConfig] snapshot, client factories, and lazily
 // constructed Helm and Kubernetes clients. Cluster does not embed
-// [Session]. Cluster REST and Kubernetes construction still prefer
-// in-cluster config when present.
+// [Session]. Cluster REST and Kubernetes construction use the Target
+// kubeconfig destination.
 package session

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -256,15 +256,11 @@ func defaultHelmFactory(t *target.Target, cfg HelmConfig) (HelmClient, error) {
 }
 
 // defaultKubernetesFactory creates a Kubernetes clientset from the resolved
-// target, preferring in-cluster config when available. That in-cluster-first
-// preference is transitional; destination metadata still comes from Target.
+// target's kubeconfig destination.
 func defaultKubernetesFactory(t *target.Target) (kubernetes.Interface, error) {
-	cfg, err := rest.InClusterConfig()
+	cfg, err := t.RESTConfig()
 	if err != nil {
-		cfg, err = t.RESTConfig()
-		if err != nil {
-			return nil, fmt.Errorf("%w (provide --kubeconfig or ensure KUBECONFIG/~/.kube/config is set)", err)
-		}
+		return nil, fmt.Errorf("%w (provide --kubeconfig or ensure KUBECONFIG/~/.kube/config is set)", err)
 	}
 	cs, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
@@ -288,10 +284,8 @@ func (s *Session) CurrentKubeContext() string {
 // Kubernetes clients. Obtain one via [Session.Target].
 //
 // Destination metadata is owned by [target.Target]. Helm construction uses
-// [HelmConfig] and [HelmFactory]. Kubernetes construction uses a
-// Target-oriented factory. RESTConfig and the default Kubernetes factory
-// still prefer in-cluster config when present; that mismatch with Target
-// metadata is transitional.
+// [HelmConfig] and [HelmFactory]. Kubernetes construction and
+// [Cluster.RESTConfig] use [target.Target.RESTConfig].
 //
 // Cluster does not embed or depend on [Session]. Concurrent [Cluster.Helm]
 // and [Cluster.Kubernetes] calls are safe.
@@ -350,17 +344,10 @@ func (cl *Cluster) Kubernetes() (kubernetes.Interface, error) {
 	return cl.k8s, nil
 }
 
-// RESTConfig returns a Kubernetes REST config for the resolved cluster.
-//
-// In-cluster config is tried first, matching historical Deployah behavior.
-// When that is unavailable, the kubeconfig destination from [target.Target]
-// is used.
+// RESTConfig returns a Kubernetes REST config for the resolved
+// [target.Target] kubeconfig destination.
 func (cl *Cluster) RESTConfig() (*rest.Config, error) {
-	cfg, err := rest.InClusterConfig()
-	if err == nil {
-		return cfg, nil
-	}
-	cfg, err = cl.target.RESTConfig()
+	cfg, err := cl.target.RESTConfig()
 	if err != nil {
 		return nil, fmt.Errorf("%w (provide --kubeconfig or ensure KUBECONFIG/~/.kube/config is set)", err)
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -451,6 +451,9 @@ func TestTarget(t *testing.T) {
 		cluster, err := sess.Target(t.Context(), "")
 		require.NoError(t, err)
 		assert.Equal(t, "custom", cluster.Namespace())
+		cfg, err := cluster.RESTConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "https://example.com:6443", cfg.Host)
 	})
 }
 
@@ -904,10 +907,38 @@ func TestCurrentKubeContext(t *testing.T) {
 	}
 }
 
-// TestClusterRESTConfig verifies Cluster.RESTConfig falls back to
-// kubeconfig resolution when no in-cluster config is available (always the
-// case in this test environment), and that it surfaces a clear error when
-// the kubeconfig cannot be resolved either.
+// twoClusterKubeconfig is a fixture with distinct API servers for dest
+// consistency tests.
+const twoClusterKubeconfig = `apiVersion: v1
+kind: Config
+current-context: dev
+clusters:
+- name: dev-cluster
+  cluster:
+    server: https://dev.example.test
+- name: prod-cluster
+  cluster:
+    server: https://prod.example.test
+contexts:
+- name: dev
+  context:
+    cluster: dev-cluster
+    user: test-user
+    namespace: sandbox
+- name: prod
+  context:
+    cluster: prod-cluster
+    user: test-user
+    namespace: payments
+users:
+- name: test-user
+  user:
+    token: fake-token
+`
+
+// TestClusterRESTConfig verifies Cluster.RESTConfig uses the Target
+// kubeconfig destination and surfaces a clear error when that dest cannot
+// be resolved.
 func TestClusterRESTConfig(t *testing.T) {
 	t.Parallel()
 
@@ -954,12 +985,114 @@ func TestClusterRESTConfig(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Contains(t, err.Error(), "provide --kubeconfig")
 				return
 			}
 			require.NoError(t, err)
 			tt.check(t, cfg)
 		})
 	}
+}
+
+func TestClusterRESTConfig_NoKubeconfig(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("HOME", t.TempDir())
+
+	cluster, err := New().Target(t.Context(), "")
+	require.NoError(t, err)
+	cfg, err := cluster.RESTConfig()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "failed to build kubernetes config")
+	assert.Contains(t, err.Error(), "provide --kubeconfig")
+}
+
+func TestClusterRESTConfigMatchesTarget(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, writeFile(path, twoClusterKubeconfig))
+
+	cluster, err := New(WithKubeconfig(path), WithKubeContext("prod")).Target(t.Context(), "")
+	require.NoError(t, err)
+	got, err := cluster.RESTConfig()
+	require.NoError(t, err)
+
+	want, err := target.NewResolver(target.Config{
+		KubeconfigPath:  path,
+		ContextOverride: "prod",
+	}).Resolve("").RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, want.Host, got.Host)
+}
+
+func TestDefaultKubernetesFactoryUsesTargetRESTConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid kubeconfig", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "kubeconfig")
+		require.NoError(t, writeFile(path, minimalKubeconfig))
+		cluster, err := New(WithKubeconfig(path)).Target(t.Context(), "")
+		require.NoError(t, err)
+		cs, err := cluster.Kubernetes()
+		require.NoError(t, err)
+		require.NotNil(t, cs)
+	})
+
+	t.Run("missing kubeconfig", func(t *testing.T) {
+		t.Parallel()
+
+		cluster, err := New(WithKubeconfig(filepath.Join(t.TempDir(), "missing-kubeconfig"))).Target(t.Context(), "")
+		require.NoError(t, err)
+		cs, err := cluster.Kubernetes()
+		require.Error(t, err)
+		assert.Nil(t, cs)
+		assert.Contains(t, err.Error(), "failed to build kubernetes config")
+		assert.Contains(t, err.Error(), "provide --kubeconfig")
+	})
+}
+
+func TestClusterClientsShareTargetDestination(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, writeFile(path, twoClusterKubeconfig))
+
+	var gotTarget *target.Target
+	var gotHelm HelmConfig
+	sess := New(
+		WithKubeconfig(path),
+		WithKubeContext("prod"),
+		WithHelmFactory(func(tgt *target.Target, cfg HelmConfig) (HelmClient, error) {
+			gotTarget = tgt
+			gotHelm = cfg
+			return &MockHelmClient{}, nil
+		}),
+	)
+	cluster, err := sess.Target(t.Context(), "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "prod", cluster.Context())
+	assert.Equal(t, target.ContextSourceExplicit, cluster.ContextSource())
+	assert.Equal(t, "payments", cluster.Namespace())
+
+	cfg, err := cluster.RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://prod.example.test", cfg.Host)
+
+	cs, err := cluster.Kubernetes()
+	require.NoError(t, err)
+	require.NotNil(t, cs)
+
+	_, err = cluster.Helm()
+	require.NoError(t, err)
+	require.NotNil(t, gotTarget)
+	assert.Equal(t, "prod", gotTarget.Context())
+	assert.Equal(t, target.ContextSourceExplicit, gotTarget.ContextSource())
+	assert.Equal(t, "payments", gotTarget.Namespace())
+	assert.Equal(t, path, gotHelm.KubeconfigPath)
 }
 
 // TestIntegrationWithMocks covers the named case.

--- a/internal/target/doc.go
+++ b/internal/target/doc.go
@@ -28,6 +28,8 @@
 // [Target.Context] is the effective context name. [Target.ContextSource]
 // records which rule selected it. When Context is non-empty, [Target.RESTConfig]
 // pins that name so the destination cannot change after Resolve.
+// [Target.RESTConfig] uses the snapshotted kubeconfig loading rules and
+// does not select in-cluster configuration.
 //
 // # Namespace precedence
 //

--- a/internal/target/resolver_test.go
+++ b/internal/target/resolver_test.go
@@ -104,26 +104,31 @@ func TestResolve_NamespacePrecedence(t *testing.T) {
 		ns       string
 		platform string
 		want     string
+		wantHost string
 	}{
 		{
 			name:     "explicit namespace wins",
 			override: "prod",
 			ns:       "custom",
 			want:     "custom",
+			wantHost: "https://prod.example.test",
 		},
 		{
 			name:     "namespace from explicit selected context",
 			override: "prod",
 			want:     "payments",
+			wantHost: "https://prod.example.test",
 		},
 		{
 			name:     "namespace from platform-selected context",
 			platform: "prod",
 			want:     "payments",
+			wantHost: "https://prod.example.test",
 		},
 		{
-			name: "namespace from kubeconfig current-context",
-			want: "sandbox",
+			name:     "namespace from kubeconfig current-context",
+			want:     "sandbox",
+			wantHost: "https://dev.example.test",
 		},
 	}
 
@@ -137,6 +142,9 @@ func TestResolve_NamespacePrecedence(t *testing.T) {
 				NamespaceOverride: tt.ns,
 			}).Resolve(tt.platform)
 			assert.Equal(t, tt.want, got.Namespace())
+			cfg, err := got.RESTConfig()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHost, cfg.Host)
 		})
 	}
 }

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -80,19 +80,23 @@ func (t *Target) Namespace() string {
 //
 // When Context is non-empty, the config pins that context. Loading rules
 // come from the snapshot taken at Resolve, not from the current process
-// environment. It does not use in-cluster configuration.
+// environment. It does not use in-cluster configuration. Load errors from
+// the snapshotted rules are returned; kubeconfig file contents are read at
+// call time.
 func (t *Target) RESTConfig() (*rest.Config, error) {
 	if t == nil {
 		return nil, fmt.Errorf("failed to build kubernetes config: target is nil")
+	}
+	rules := t.loading.clientConfigLoadingRules()
+	raw, err := rules.Load()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubernetes config: %w", err)
 	}
 	overrides := &clientcmd.ConfigOverrides{}
 	if t.contextName != "" {
 		overrides.CurrentContext = t.contextName
 	}
-	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		t.loading.clientConfigLoadingRules(),
-		overrides,
-	).ClientConfig()
+	cfg, err := clientcmd.NewNonInteractiveClientConfig(*raw, "", overrides, rules).ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build kubernetes config: %w", err)
 	}

--- a/internal/target/target_test.go
+++ b/internal/target/target_test.go
@@ -97,6 +97,21 @@ users:
 	assert.NotContains(t, err.Error(), "fake-token")
 }
 
+func TestRESTConfig_EmptyKubeconfigIsError(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("HOME", t.TempDir())
+
+	got := target.NewResolver(target.Config{}).Resolve("")
+	assert.Empty(t, got.Context())
+	assert.Equal(t, target.ContextSourceKubeconfig, got.ContextSource())
+	assert.Equal(t, "default", got.Namespace())
+
+	cfg, err := got.RESTConfig()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "failed to build kubernetes config")
+}
+
 func TestTarget_DoesNotReresolveAfterKUBECONFIGChange(t *testing.T) {
 	a := writeKubeconfig(t, twoClusterKubeconfig("dev", "", ""))
 	b := writeKubeconfig(t, twoClusterKubeconfig("prod", "", ""))


### PR DESCRIPTION
## Summary

- stop Cluster REST and Kubernetes from preferring in-cluster config when a kubeconfig dest is already selected
- build `Target.RESTConfig` from snapshotted kubeconfig rules only, so empty or missing kubeconfig is an error
- keep Helm construction unchanged; remaining Helm loader drift is follow-up

This is a safety fix. Running the CLI in a Pod with only a service account now fails with the existing kubeconfig error instead of silently using the Pod API server.

## Related

Follows #125 (Workspace), #124 (Cluster), #123 (`internal/workspace`), and #122 (`internal/target`).

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `nix run .#lint` / pre-commit clean
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore`
- [x] Add `breaking-change` if this breaks existing CLI or config behavior
- [ ] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [x] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`)
- [x] No secrets or local-only paths in the diff