### PR TITLE
fix helm kubernetes dest selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/api v0.37.0
 	k8s.io/apiextensions-apiserver v0.37.0
 	k8s.io/apimachinery v0.37.0
+	k8s.io/cli-runtime v0.37.0
 	k8s.io/client-go v0.37.0
 	mvdan.cc/sh/v3 v3.14.1
 	nabat.dev v0.9.0
@@ -228,7 +229,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.37.0 // indirect
-	k8s.io/cli-runtime v0.37.0 // indirect
 	k8s.io/component-base v0.37.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260821135717-be32def86098 // indirect

--- a/internal/helm/dest_test.go
+++ b/internal/helm/dest_test.go
@@ -1,0 +1,308 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"deployah.dev/deployah/internal/spec"
+	"deployah.dev/deployah/internal/target"
+
+	diskcached "k8s.io/client-go/discovery/cached/disk"
+)
+
+func TestRESTClientGetter_MatchesTargetHostAndWrap(t *testing.T) {
+	t.Parallel()
+
+	path := writeDestKubeconfig(t, destTwoClusterKubeconfig("dev", "", ""))
+	tgt := target.NewResolver(target.Config{
+		KubeconfigPath:  path,
+		ContextOverride: "prod",
+	}).Resolve("")
+
+	want, err := tgt.RESTConfig()
+	require.NoError(t, err)
+
+	getter := NewRESTClientGetter(tgt.ClientConfig())
+	got, err := getter.ToRESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, want.Host, got.Host)
+	assert.Equal(t, 100, got.Burst)
+	assert.Equal(t, float32(0), got.QPS)
+	assert.Equal(t, "Helm/4.3", got.UserAgent)
+	assert.NotNil(t, got.WrapTransport)
+
+	assert.Zero(t, want.Burst)
+	assert.NotEqual(t, "Helm/4.3", want.UserAgent)
+}
+
+func TestRESTClientGetter_MissingExtraUsesDefault(t *testing.T) {
+	def := writeDestKubeconfig(t, destSingleKubeconfig("home", "https://home.example.test"))
+	t.Setenv("KUBECONFIG", def)
+	t.Setenv("HOME", t.TempDir())
+
+	tgt := target.NewResolver(target.Config{
+		ExtraKubeconfigPaths: []string{filepath.Join(t.TempDir(), "missing-local")},
+	}).Resolve("")
+	want, err := tgt.RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://home.example.test", want.Host)
+
+	client, err := NewClient(
+		WithRESTClientGetter(NewRESTClientGetter(tgt.ClientConfig())),
+		WithNamespace(tgt.Namespace()),
+	)
+	require.NoError(t, err)
+	got, err := client.restGetter.ToRESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, want.Host, got.Host)
+}
+
+func TestRESTClientGetter_MultiFileKubeconfig(t *testing.T) {
+	a := writeDestKubeconfig(t, destSingleKubeconfig("dev", "https://dev.example.test"))
+	b := writeDestKubeconfig(t, destSingleKubeconfig("prod", "https://prod.example.test"))
+	t.Setenv("KUBECONFIG", a+string(os.PathListSeparator)+b)
+	t.Setenv("HOME", t.TempDir())
+
+	tgt := target.NewResolver(target.Config{ContextOverride: "prod"}).Resolve("")
+	want, err := tgt.RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://prod.example.test", want.Host)
+
+	got, err := NewRESTClientGetter(tgt.ClientConfig()).ToRESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, want.Host, got.Host)
+}
+
+func TestRESTClientGetter_IgnoresLiveEnvAfterResolve(t *testing.T) {
+	a := writeDestKubeconfig(t, destSingleKubeconfig("dev", "https://dev.example.test"))
+	b := writeDestKubeconfig(t, destSingleKubeconfig("prod", "https://prod.example.test"))
+	t.Setenv("KUBECONFIG", a)
+	t.Setenv("HOME", t.TempDir())
+
+	tgt := target.NewResolver(target.Config{}).Resolve("")
+	t.Setenv("KUBECONFIG", b)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HELM_KUBEAPISERVER", "https://other.example")
+	t.Setenv("HELM_KUBECONTEXT", "prod")
+	t.Setenv("HELM_NAMESPACE", "helm-ns")
+	t.Setenv("HELM_KUBETOKEN", "helm-token")
+
+	want, err := tgt.RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://dev.example.test", want.Host)
+
+	getter := NewRESTClientGetter(tgt.ClientConfig())
+	got, err := getter.ToRESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, want.Host, got.Host)
+	assert.NotEqual(t, "helm-token", got.BearerToken)
+
+	ns, _, err := getter.ToRawKubeConfigLoader().Namespace()
+	require.NoError(t, err)
+	assert.Equal(t, tgt.Namespace(), ns)
+}
+
+func TestRESTClientGetter_PinsExplicitNamespace(t *testing.T) {
+	t.Parallel()
+
+	path := writeDestKubeconfig(t, destTwoClusterKubeconfig("dev", "sandbox", "payments"))
+	tgt := target.NewResolver(target.Config{
+		KubeconfigPath:    path,
+		ContextOverride:   "prod",
+		NamespaceOverride: "cli-ns",
+	}).Resolve("")
+
+	ns, overridden, err := NewRESTClientGetter(tgt.ClientConfig()).ToRawKubeConfigLoader().Namespace()
+	require.NoError(t, err)
+	assert.True(t, overridden)
+	assert.Equal(t, "cli-ns", ns)
+}
+
+func TestRESTClientGetter_DiscoveryIsLazy(t *testing.T) {
+	t.Setenv("KUBECACHEDIR", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	path := writeDestKubeconfig(t, destSingleKubeconfig("dev", "https://dev.example.test"))
+	tgt := target.NewResolver(target.Config{KubeconfigPath: path}).Resolve("")
+	getter := NewRESTClientGetter(tgt.ClientConfig())
+
+	dc, err := getter.ToDiscoveryClient()
+	require.NoError(t, err)
+	_, ok := dc.(*diskcached.CachedDiscoveryClient)
+	require.True(t, ok)
+	dc.Invalidate()
+
+	mapper, err := getter.ToRESTMapper()
+	require.NoError(t, err)
+	require.NotNil(t, mapper)
+}
+
+func TestRESTClientGetter_UnconfiguredDiscoveryFails(t *testing.T) {
+	t.Parallel()
+
+	getter := NewRESTClientGetter(nil)
+	_, err := getter.ToDiscoveryClient()
+	require.ErrorIs(t, err, ErrDestinationNotConfigured)
+	_, err = getter.ToRESTMapper()
+	require.ErrorIs(t, err, ErrDestinationNotConfigured)
+}
+
+func TestRESTClientGetter_NoInClusterFallback(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	tgt := target.NewResolver(target.Config{}).Resolve("")
+	_, err := NewRESTClientGetter(tgt.ClientConfig()).ToRESTConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build kubernetes config")
+}
+
+func TestNewClient_HELMNamespaceDoesNotOverrideStoredNamespace(t *testing.T) {
+	t.Setenv("HELM_NAMESPACE", "helm-ns")
+
+	client, err := NewClient(WithNamespace("deployah-ns"))
+	require.NoError(t, err)
+	assert.Equal(t, "deployah-ns", client.Namespace())
+}
+
+func TestNewClient_UnconfiguredGetterIgnoresAmbientKubeconfig(t *testing.T) {
+	path := writeDestKubeconfig(t, destSingleKubeconfig("prod", "https://prod.example.test"))
+	t.Setenv("KUBECONFIG", path)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HELM_KUBEAPISERVER", "https://other.example")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	tests := []struct {
+		name string
+		opts []Option
+	}{
+		{name: "no getter", opts: []Option{WithNamespace("default")}},
+		{name: "nil getter", opts: []Option{WithRESTClientGetter(nil), WithNamespace("default")}},
+	}
+	m := envServiceSpec(t.TempDir(), spec.StringMap{"LOG_LEVEL": "debug"})
+	resolved := resolveChart(t, m, "dev")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(tt.opts...)
+			require.NoError(t, err)
+			require.NotNil(t, client.restGetter)
+
+			_, err = client.restGetter.ToRESTConfig()
+			require.ErrorIs(t, err, ErrDestinationNotConfigured)
+
+			err = client.IsReachable()
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrDestinationNotConfigured)
+
+			result, cleanup, err := client.RenderOffline(t.Context(), resolved, nil)
+			require.NoError(t, err)
+			if cleanup != nil {
+				t.Cleanup(cleanup)
+			}
+			require.NotNil(t, result)
+			assert.Equal(t, "default", result.Namespace)
+		})
+	}
+}
+
+func TestNewClient_OfflineRenderWithoutKubeconfig(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "missing-kubeconfig"))
+	t.Setenv("HOME", t.TempDir())
+
+	client, err := NewClient(WithNamespace("default"))
+	require.NoError(t, err)
+
+	m := envServiceSpec(t.TempDir(), spec.StringMap{"LOG_LEVEL": "debug"})
+	resolved := resolveChart(t, m, "dev")
+	result, cleanup, err := client.RenderOffline(t.Context(), resolved, nil)
+	require.NoError(t, err)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+	require.NotNil(t, result)
+	assert.Equal(t, "default", result.Namespace)
+}
+
+func writeDestKubeconfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func destTwoClusterKubeconfig(current, devNS, prodNS string) string {
+	return `apiVersion: v1
+kind: Config
+current-context: ` + current + `
+clusters:
+- name: dev-cluster
+  cluster:
+    server: https://dev.example.test
+- name: prod-cluster
+  cluster:
+    server: https://prod.example.test
+contexts:
+- name: dev
+  context:
+    cluster: dev-cluster
+    user: test-user` + destContextNamespaceYAML(devNS) + `
+- name: prod
+  context:
+    cluster: prod-cluster
+    user: test-user` + destContextNamespaceYAML(prodNS) + `
+users:
+- name: test-user
+  user:
+    token: fake-token
+`
+}
+
+func destSingleKubeconfig(contextName, server string) string {
+	return `apiVersion: v1
+kind: Config
+current-context: ` + contextName + `
+clusters:
+- name: ` + contextName + `
+  cluster:
+    server: ` + server + `
+contexts:
+- name: ` + contextName + `
+  context:
+    cluster: ` + contextName + `
+    user: test-user
+users:
+- name: test-user
+  user:
+    token: fake-token
+`
+}
+
+func destContextNamespaceYAML(ns string) string {
+	if ns == "" {
+		return ""
+	}
+	return `
+    namespace: ` + ns
+}

--- a/internal/helm/doc.go
+++ b/internal/helm/doc.go
@@ -18,4 +18,6 @@
 // [PrepareChart] renders templates and values for an environment into a
 // caller-supplied [ChartCache]. [Client] wraps Helm v4 actions with
 // Deployah-specific release naming, labels, and a per-client [ChartCache].
+// Kubernetes destination comes from a caller-supplied REST client getter
+// via [NewRESTClientGetter]; [Client] does not select a kubeconfig itself.
 package helm

--- a/internal/helm/generate_schedule_test.go
+++ b/internal/helm/generate_schedule_test.go
@@ -396,7 +396,7 @@ func renderScheduled(t *testing.T, manifest *spec.Spec, env, releaseName, kubeVe
 
 	install := action.NewInstall(client.config)
 	install.ReleaseName = releaseName
-	install.Namespace = client.settings.Namespace()
+	install.Namespace = client.Namespace()
 	install.CreateNamespace = true
 	install.DryRunStrategy = action.DryRunClient
 	install.DisableOpenAPIValidation = true

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -13,13 +13,13 @@ import (
 
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
-	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/kube"
 	"helm.sh/helm/v4/pkg/postrenderer"
 	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/storage/driver"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"deployah.dev/deployah/internal/spec"
 
@@ -50,50 +50,32 @@ var (
 
 // Client wraps Helm action configuration for Deployah operations.
 type Client struct {
-	settings             *cli.EnvSettings
-	config               *action.Configuration
-	timeout              time.Duration
-	namespace            string
-	kubeconfig           string
-	kubeContext          string
-	extraKubeconfigPaths []string
-	storageDriver        string
-	debug                bool
-	chartCache           *ChartCache
+	restGetter    genericclioptions.RESTClientGetter
+	config        *action.Configuration
+	timeout       time.Duration
+	namespace     string
+	storageDriver string
+	debug         bool
+	chartCache    *ChartCache
 }
 
 // Option is a functional option for configuring the Helm client
 type Option func(*Client)
 
-// WithNamespace sets the Kubernetes namespace for Helm operations
+// WithNamespace sets the Kubernetes namespace for Helm operations.
+// Empty falls back to "default" in [NewClient].
 func WithNamespace(namespace string) Option {
 	return func(c *Client) {
 		c.namespace = namespace
 	}
 }
 
-// WithKubeconfig sets the path to the kubeconfig file
-func WithKubeconfig(kubeconfig string) Option {
+// WithRESTClientGetter sets the Kubernetes REST client getter used by Helm
+// actions. A nil getter is treated as unset; [NewClient] then installs an
+// unconfigured getter so [action.Configuration.Init] never receives nil.
+func WithRESTClientGetter(getter genericclioptions.RESTClientGetter) Option {
 	return func(c *Client) {
-		c.kubeconfig = kubeconfig
-	}
-}
-
-// WithKubeContext sets the Kubernetes context to use, overriding the
-// kubeconfig's current context.
-func WithKubeContext(kubeContext string) Option {
-	return func(c *Client) {
-		c.kubeContext = kubeContext
-	}
-}
-
-// WithExtraKubeconfigPaths appends additional kubeconfig file paths so their
-// contexts are available alongside the default kubeconfig. This is ignored
-// when WithKubeconfig is also set, because an explicit path takes full
-// precedence and makes extra paths redundant.
-func WithExtraKubeconfigPaths(paths ...string) Option {
-	return func(c *Client) {
-		c.extraKubeconfigPaths = append(c.extraKubeconfigPaths, paths...)
+		c.restGetter = getter
 	}
 }
 
@@ -130,6 +112,8 @@ func WithChartCache(cache *ChartCache) Option {
 // Default storage driver is "secret" if not specified.
 // Default timeout is 5 minutes if not specified.
 // Each client gets its own [ChartCache] unless [WithChartCache] is set.
+// A missing [WithRESTClientGetter] (including a nil getter) uses an
+// unconfigured getter so [action.Configuration.Init] never receives nil.
 func NewClient(opts ...Option) (*Client, error) {
 	c := &Client{
 		storageDriver: "secret",
@@ -143,35 +127,11 @@ func NewClient(opts ...Option) (*Client, error) {
 	if c.chartCache == nil {
 		return nil, errors.New("chart cache is required")
 	}
-
-	settings := cli.New()
-
-	// An explicit kubeconfig takes full precedence; extra paths are ignored,
-	// matching client-go's ExplicitPath semantics. Otherwise prepend the extra
-	// paths before the default kubeconfig so deployah-managed contexts (e.g.
-	// a recreated Kind cluster) take priority over stale entries in
-	// ~/.kube/config.
-	if c.kubeconfig != "" {
-		settings.KubeConfig = c.kubeconfig
-	} else if len(c.extraKubeconfigPaths) > 0 {
-		all := make([]string, 0, len(c.extraKubeconfigPaths)+1)
-		all = append(all, c.extraKubeconfigPaths...)
-		all = append(all, settings.KubeConfig)
-		var parts []string
-		for _, p := range all {
-			if p != "" {
-				parts = append(parts, p)
-			}
-		}
-		if len(parts) > 0 {
-			settings.KubeConfig = strings.Join(parts, string(os.PathListSeparator))
-		}
+	if c.namespace == "" {
+		c.namespace = "default"
 	}
-	if c.kubeContext != "" {
-		settings.KubeContext = c.kubeContext
-	}
-	if c.namespace != "" {
-		settings.SetNamespace(c.namespace)
+	if c.restGetter == nil {
+		c.restGetter = NewRESTClientGetter(nil)
 	}
 
 	validDrivers := map[string]bool{"secret": true, "configmap": true, "memory": true}
@@ -180,23 +140,20 @@ func NewClient(opts ...Option) (*Client, error) {
 	}
 
 	c.config = new(action.Configuration)
-	if err := c.config.Init(settings.RESTClientGetter(), settings.Namespace(), c.storageDriver); err != nil {
+	if err := c.config.Init(c.restGetter, c.namespace, c.storageDriver); err != nil {
 		return nil, fmt.Errorf("failed to initialize Helm configuration: %w", err)
 	}
-
-	c.settings = settings
 
 	return c, nil
 }
 
 // Namespace returns the release namespace Helm will use for installs and
-// offline renders (from WithNamespace, HELM_NAMESPACE, or the kubeconfig
-// context default).
+// offline renders. It comes from [WithNamespace], or "default" when empty.
 func (c *Client) Namespace() string {
-	if c == nil || c.settings == nil {
-		return ""
+	if c == nil || c.namespace == "" {
+		return "default"
 	}
-	return c.settings.Namespace()
+	return c.namespace
 }
 
 // IsReachable reports whether the configured Kubernetes cluster is reachable.
@@ -277,7 +234,7 @@ func (c *Client) InstallApp(ctx context.Context, dryRun bool, resolved *spec.Res
 		// attempt as well.
 		install := action.NewInstall(c.config)
 		install.ReleaseName = releaseName
-		install.Namespace = c.settings.Namespace()
+		install.Namespace = c.Namespace()
 		install.CreateNamespace = true
 		install.Timeout = c.timeout
 		install.WaitStrategy = kube.StatusWatcherStrategy
@@ -293,7 +250,7 @@ func (c *Client) InstallApp(ctx context.Context, dryRun bool, resolved *spec.Res
 
 	// Upgrade existing release
 	upgrade := action.NewUpgrade(c.config)
-	upgrade.Namespace = c.settings.Namespace()
+	upgrade.Namespace = c.Namespace()
 	upgrade.Timeout = c.timeout
 	upgrade.RollbackOnFailure = true
 	upgrade.WaitStrategy = kube.StatusWatcherStrategy

--- a/internal/helm/helm_error_test.go
+++ b/internal/helm/helm_error_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v4/pkg/action"
-	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/release/common"
 	"helm.sh/helm/v4/pkg/storage"
 	"helm.sh/helm/v4/pkg/storage/driver"
@@ -212,12 +211,10 @@ func TestInstallApp_PendingReleaseRejects(t *testing.T) {
 		Releases:   storage.Init(driver.NewMemory()),
 		KubeClient: &kubefake.PrintingKubeClient{Out: io.Discard},
 	}
-	settings := cli.New()
-	settings.SetNamespace("default")
 
 	c := &Client{
 		config:     cfg,
-		settings:   settings,
+		namespace:  "default",
 		timeout:    time.Minute,
 		chartCache: NewChartCache(time.Hour),
 	}

--- a/internal/helm/render.go
+++ b/internal/helm/render.go
@@ -165,7 +165,7 @@ func (c *Client) renderInstall(ctx context.Context, releaseName string, ch *char
 
 	install := action.NewInstall(c.config)
 	install.ReleaseName = releaseName
-	install.Namespace = c.settings.Namespace()
+	install.Namespace = c.Namespace()
 	install.CreateNamespace = true
 	install.DryRunStrategy = action.DryRunClient
 	install.DisableOpenAPIValidation = true
@@ -203,7 +203,7 @@ func (c *Client) renderUpgrade(ctx context.Context, releaseName string, ch *char
 	defer restoreConfigForDryRun(c.config)()
 
 	upgrade := action.NewUpgrade(c.config)
-	upgrade.Namespace = c.settings.Namespace()
+	upgrade.Namespace = c.Namespace()
 	upgrade.DryRunStrategy = action.DryRunClient
 	upgrade.DisableOpenAPIValidation = true
 	upgrade.Labels = labels

--- a/internal/helm/rest_getter.go
+++ b/internal/helm/rest_getter.go
@@ -1,0 +1,148 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"helm.sh/helm/v4/pkg/kubeenv"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+
+	diskcached "k8s.io/client-go/discovery/cached/disk"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	helmBurstLimit    = 100
+	helmQPS           = float32(0)
+	helmUserAgent     = "Helm/4.3"
+	discoveryCacheTTL = 6 * time.Hour
+	discoveryBurst    = 0
+	discoveryQPS      = float32(0)
+)
+
+var (
+	_ genericclioptions.RESTClientGetter = (*restClientGetter)(nil)
+	_ clientcmd.ClientConfig             = unconfiguredClientConfig{}
+
+	overlyCautiousIllegalFileCharacters = regexp.MustCompile(`[^(\w/.)]`)
+)
+
+// ErrDestinationNotConfigured is returned when a Helm client has no
+// Kubernetes destination and an operation needs one.
+var ErrDestinationNotConfigured = errors.New("kubernetes destination is not configured")
+
+// NewRESTClientGetter returns a Helm REST client getter backed by cc.
+// A nil cc yields an unconfigured getter: online Kubernetes access fails
+// with [ErrDestinationNotConfigured] and does not select an ambient
+// kubeconfig or in-cluster destination.
+func NewRESTClientGetter(cc clientcmd.ClientConfig) genericclioptions.RESTClientGetter {
+	if cc == nil {
+		cc = unconfiguredClientConfig{}
+	}
+	return &restClientGetter{cc: cc}
+}
+
+type restClientGetter struct {
+	cc clientcmd.ClientConfig
+}
+
+func (g *restClientGetter) ToRESTConfig() (*rest.Config, error) {
+	cfg, err := g.cc.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return applyHelmRESTRuntime(cfg), nil
+}
+
+func (g *restClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return g.cc
+}
+
+func (g *restClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	config, err := g.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	config.Burst = discoveryBurst
+	config.QPS = discoveryQPS
+
+	cacheDir := defaultKubeCacheDir()
+	httpCacheDir := filepath.Join(cacheDir, "http")
+	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, "discovery"), config.Host)
+	return diskcached.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, discoveryCacheTTL)
+}
+
+func (g *restClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	discoveryClient, err := g.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	return restmapper.NewShortcutExpander(mapper, discoveryClient, func(string) {}), nil
+}
+
+func applyHelmRESTRuntime(cfg *rest.Config) *rest.Config {
+	cfg.Burst = helmBurstLimit
+	cfg.QPS = helmQPS
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &kubeenv.RetryingRoundTripper{Wrapped: rt}
+	})
+	cfg.UserAgent = helmUserAgent
+	return cfg
+}
+
+func defaultKubeCacheDir() string {
+	if kcd := os.Getenv("KUBECACHEDIR"); kcd != "" {
+		return kcd
+	}
+	return filepath.Join(homedir.HomeDir(), ".kube", "cache")
+}
+
+func computeDiscoverCacheDir(parentDir, host string) string {
+	schemelessHost := strings.Replace(strings.Replace(host, "https://", "", 1), "http://", "", 1)
+	safeHost := overlyCautiousIllegalFileCharacters.ReplaceAllString(schemelessHost, "_")
+	return filepath.Join(parentDir, safeHost)
+}
+
+type unconfiguredClientConfig struct{}
+
+func (unconfiguredClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return clientcmdapi.Config{}, ErrDestinationNotConfigured
+}
+
+func (unconfiguredClientConfig) ClientConfig() (*rest.Config, error) {
+	return nil, ErrDestinationNotConfigured
+}
+
+func (unconfiguredClientConfig) Namespace() (string, bool, error) {
+	return "default", false, nil
+}
+
+func (unconfiguredClientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	return &clientcmd.ClientConfigLoadingRules{}
+}

--- a/internal/session/doc.go
+++ b/internal/session/doc.go
@@ -25,6 +25,6 @@
 // the environment name to obtain a [Cluster] that holds the resolved
 // [target.Target], a [HelmConfig] snapshot, client factories, and lazily
 // constructed Helm and Kubernetes clients. Cluster does not embed
-// [Session]. Cluster REST and Kubernetes construction use the Target
-// kubeconfig destination.
+// [Session]. Cluster REST, Kubernetes, and Helm construction use the
+// Target kubeconfig destination.
 package session

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -50,11 +50,12 @@ type Session struct {
 // [Session.Target] snapshots these values onto [Cluster]. Session accessors
 // such as [Session.Timeout] keep reading the Session fields.
 type HelmConfig struct {
-	// KubeconfigPath is an explicit kubeconfig file. Empty means Helm uses
-	// extra paths, then process KUBECONFIG / the default kubeconfig.
+	// KubeconfigPath is the explicit kubeconfig path snapshotted from
+	// Session. Destination selection uses [target.Target], not this field.
 	KubeconfigPath string
-	// ExtraKubeconfigPaths are prepended to Helm's default kubeconfig when
-	// KubeconfigPath is empty. Missing files are tolerated by Helm.
+	// ExtraKubeconfigPaths is the extra kubeconfig path list snapshotted
+	// from Session. Destination selection uses [target.Target], not this
+	// field.
 	ExtraKubeconfigPaths []string
 	// StorageDriver is the Helm storage driver (secret, configmap, or memory).
 	// Empty lets [helm.NewClient] use its default ("secret").
@@ -227,21 +228,12 @@ func (s *Session) KubeContext() string { return s.kubeContext }
 func (s *Session) Timeout() time.Duration { return s.timeout }
 
 // defaultHelmFactory creates a Helm client from the resolved destination and
-// Helm runtime configuration. Context and namespace come from t; kubeconfig
-// paths, storage driver, timeout, and debug come from cfg.
+// Helm runtime configuration. Destination comes from t.ClientConfig();
+// storage driver, timeout, and debug come from cfg.
 func defaultHelmFactory(t *target.Target, cfg HelmConfig) (HelmClient, error) {
-	var opts []helm.Option
-	if ns := t.Namespace(); ns != "" {
-		opts = append(opts, helm.WithNamespace(ns))
-	}
-	if cfg.KubeconfigPath != "" {
-		opts = append(opts, helm.WithKubeconfig(cfg.KubeconfigPath))
-	}
-	if kubeContext := t.Context(); kubeContext != "" {
-		opts = append(opts, helm.WithKubeContext(kubeContext))
-	}
-	if len(cfg.ExtraKubeconfigPaths) > 0 {
-		opts = append(opts, helm.WithExtraKubeconfigPaths(cfg.ExtraKubeconfigPaths...))
+	opts := []helm.Option{
+		helm.WithRESTClientGetter(helm.NewRESTClientGetter(t.ClientConfig())),
+		helm.WithNamespace(t.Namespace()),
 	}
 	if cfg.StorageDriver != "" {
 		opts = append(opts, helm.WithStorageDriver(cfg.StorageDriver))
@@ -284,8 +276,9 @@ func (s *Session) CurrentKubeContext() string {
 // Kubernetes clients. Obtain one via [Session.Target].
 //
 // Destination metadata is owned by [target.Target]. Helm construction uses
-// [HelmConfig] and [HelmFactory]. Kubernetes construction and
-// [Cluster.RESTConfig] use [target.Target.RESTConfig].
+// [target.Target.ClientConfig], [HelmConfig], and [HelmFactory].
+// Kubernetes construction and [Cluster.RESTConfig] use
+// [target.Target.RESTConfig].
 //
 // Cluster does not embed or depend on [Session]. Concurrent [Cluster.Helm]
 // and [Cluster.Kubernetes] calls are safe.

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
@@ -33,7 +35,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 
-	"deployah.dev/deployah/internal/helm"
 	"deployah.dev/deployah/internal/render"
 	"deployah.dev/deployah/internal/spec"
 	"deployah.dev/deployah/internal/target"
@@ -1097,8 +1098,48 @@ func TestClusterClientsShareTargetDestination(t *testing.T) {
 }
 
 func TestDefaultHelmFactory_MissingExtraUsesDefaultKubeconfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/version" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"major":"1","minor":"37","gitVersion":"v1.37.0"}`))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	kubeconfig := fmt.Sprintf(`apiVersion: v1
+kind: Config
+current-context: dev
+clusters:
+- name: dev-cluster
+  cluster:
+    server: %s
+- name: prod-cluster
+  cluster:
+    server: http://127.0.0.1:1
+contexts:
+- name: dev
+  context:
+    cluster: dev-cluster
+    user: test-user
+    namespace: sandbox
+- name: prod
+  context:
+    cluster: prod-cluster
+    user: test-user
+    namespace: payments
+users:
+- name: test-user
+  user:
+    token: fake-token
+`, srv.URL)
 	path := filepath.Join(t.TempDir(), "kubeconfig")
-	require.NoError(t, writeFile(path, twoClusterKubeconfig))
+	require.NoError(t, writeFile(path, kubeconfig))
 	t.Setenv("KUBECONFIG", path)
 	t.Setenv("HOME", t.TempDir())
 
@@ -1108,16 +1149,12 @@ func TestDefaultHelmFactory_MissingExtraUsesDefaultKubeconfig(t *testing.T) {
 
 	want, err := cluster.RESTConfig()
 	require.NoError(t, err)
-	assert.Equal(t, "https://dev.example.test", want.Host)
+	assert.Equal(t, srv.URL, want.Host)
 
 	helmClient, err := cluster.Helm()
 	require.NoError(t, err)
 	require.NotNil(t, helmClient)
-
-	err = helmClient.IsReachable()
-	require.Error(t, err)
-	assert.ErrorIs(t, err, helm.ErrClusterUnreachable)
-	assert.NotErrorIs(t, err, helm.ErrDestinationNotConfigured)
+	require.NoError(t, helmClient.IsReachable())
 }
 
 func TestIntegrationWithMocks(t *testing.T) {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 
+	"deployah.dev/deployah/internal/helm"
 	"deployah.dev/deployah/internal/render"
 	"deployah.dev/deployah/internal/spec"
 	"deployah.dev/deployah/internal/target"
@@ -1095,7 +1096,30 @@ func TestClusterClientsShareTargetDestination(t *testing.T) {
 	assert.Equal(t, path, gotHelm.KubeconfigPath)
 }
 
-// TestIntegrationWithMocks covers the named case.
+func TestDefaultHelmFactory_MissingExtraUsesDefaultKubeconfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, writeFile(path, twoClusterKubeconfig))
+	t.Setenv("KUBECONFIG", path)
+	t.Setenv("HOME", t.TempDir())
+
+	sess := New(WithExtraKubeconfigPaths(filepath.Join(t.TempDir(), "missing-local")))
+	cluster, err := sess.Target(t.Context(), "")
+	require.NoError(t, err)
+
+	want, err := cluster.RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://dev.example.test", want.Host)
+
+	helmClient, err := cluster.Helm()
+	require.NoError(t, err)
+	require.NotNil(t, helmClient)
+
+	err = helmClient.IsReachable()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, helm.ErrClusterUnreachable)
+	assert.NotErrorIs(t, err, helm.ErrDestinationNotConfigured)
+}
+
 func TestIntegrationWithMocks(t *testing.T) {
 	t.Run("full workflow with mock helm client", func(t *testing.T) {
 		mockHelm := &MockHelmClient{}

--- a/internal/target/clientconfig.go
+++ b/internal/target/clientconfig.go
@@ -1,0 +1,119 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package target
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+var _ clientcmd.ClientConfig = (*clientConfig)(nil)
+
+// ClientConfig returns a lazy Kubernetes client configuration for this
+// destination.
+//
+// The returned value does not read kubeconfig files until RawConfig or
+// ClientConfig is called. Namespace returns the Target namespace without
+// loading. When Context is non-empty, that context is pinned. Namespace is
+// always pinned to [Target.Namespace]. Loading rules come from the Resolve
+// snapshot. It does not use in-cluster configuration.
+func (t *Target) ClientConfig() clientcmd.ClientConfig {
+	if t == nil {
+		return &clientConfig{nilTarget: true, namespace: defaultNamespace}
+	}
+	return &clientConfig{
+		loading:   t.loading,
+		context:   t.contextName,
+		namespace: t.Namespace(),
+	}
+}
+
+// clientConfig is a Target-owned [clientcmd.ClientConfig] that loads
+// snapshotted rules on demand and pins context and namespace.
+type clientConfig struct {
+	loading   loadingSnapshot
+	context   string
+	namespace string
+	nilTarget bool
+}
+
+func (c *clientConfig) overrides() *clientcmd.ConfigOverrides {
+	ns := c.namespace
+	if ns == "" {
+		ns = defaultNamespace
+	}
+	overrides := &clientcmd.ConfigOverrides{
+		Context: clientcmdapi.Context{Namespace: ns},
+	}
+	if c.context != "" {
+		overrides.CurrentContext = c.context
+	}
+	return overrides
+}
+
+func (c *clientConfig) direct() (clientcmd.OverridingClientConfig, error) {
+	if c == nil || c.nilTarget {
+		return nil, fmt.Errorf("failed to build kubernetes config: target is nil")
+	}
+	rules := c.loading.clientConfigLoadingRules()
+	raw, err := rules.Load()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubernetes config: %w", err)
+	}
+	return clientcmd.NewNonInteractiveClientConfig(*raw, "", c.overrides(), rules), nil
+}
+
+func (c *clientConfig) RawConfig() (clientcmdapi.Config, error) {
+	cc, err := c.direct()
+	if err != nil {
+		return clientcmdapi.Config{}, err
+	}
+	merged, err := cc.MergedRawConfig()
+	if err != nil {
+		return clientcmdapi.Config{}, fmt.Errorf("failed to build kubernetes config: %w", err)
+	}
+	return merged, nil
+}
+
+func (c *clientConfig) ClientConfig() (*rest.Config, error) {
+	cc, err := c.direct()
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := cc.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubernetes config: %w", err)
+	}
+	return cfg, nil
+}
+
+func (c *clientConfig) Namespace() (string, bool, error) {
+	ns := defaultNamespace
+	if c != nil && c.namespace != "" {
+		ns = c.namespace
+	}
+	return ns, true, nil
+}
+
+func (c *clientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	if c == nil {
+		return &clientcmd.ClientConfigLoadingRules{}
+	}
+	return c.loading.clientConfigLoadingRules()
+}

--- a/internal/target/clientconfig_test.go
+++ b/internal/target/clientconfig_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package target_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"deployah.dev/deployah/internal/target"
+)
+
+func TestClientConfig_IsLazyWhenKubeconfigMissing(t *testing.T) {
+	t.Parallel()
+
+	got := target.NewResolver(target.Config{
+		KubeconfigPath:    filepath.Join(t.TempDir(), "missing-kubeconfig"),
+		NamespaceOverride: "cli-ns",
+	}).Resolve("")
+
+	cc := got.ClientConfig()
+	require.NotNil(t, cc)
+
+	ns, overridden, err := cc.Namespace()
+	require.NoError(t, err)
+	assert.True(t, overridden)
+	assert.Equal(t, "cli-ns", ns)
+
+	_, err = cc.ClientConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build kubernetes config")
+
+	_, err = cc.RawConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build kubernetes config")
+}
+
+func TestClientConfig_PinsNamespaceOverKubeconfigContext(t *testing.T) {
+	t.Parallel()
+
+	path := writeKubeconfig(t, twoClusterKubeconfig("dev", "sandbox", "payments"))
+	got := target.NewResolver(target.Config{
+		KubeconfigPath:    path,
+		ContextOverride:   "prod",
+		NamespaceOverride: "cli-ns",
+	}).Resolve("")
+
+	assert.Equal(t, "cli-ns", got.Namespace())
+
+	ns, overridden, err := got.ClientConfig().Namespace()
+	require.NoError(t, err)
+	assert.True(t, overridden)
+	assert.Equal(t, "cli-ns", ns)
+}
+
+func TestClientConfig_MatchesRESTConfig(t *testing.T) {
+	t.Parallel()
+
+	path := writeKubeconfig(t, twoClusterKubeconfig("dev", "", ""))
+	got := target.NewResolver(target.Config{
+		KubeconfigPath:  path,
+		ContextOverride: "prod",
+	}).Resolve("")
+
+	restCfg, err := got.RESTConfig()
+	require.NoError(t, err)
+	ccCfg, err := got.ClientConfig().ClientConfig()
+	require.NoError(t, err)
+	assert.Equal(t, restCfg.Host, ccCfg.Host)
+	assert.Equal(t, "https://prod.example.test", ccCfg.Host)
+}
+
+func TestClientConfig_RawConfigIsTargetMerged(t *testing.T) {
+	t.Parallel()
+
+	path := writeKubeconfig(t, twoClusterKubeconfig("dev", "sandbox", "payments"))
+	got := target.NewResolver(target.Config{
+		KubeconfigPath:    path,
+		ContextOverride:   "prod",
+		NamespaceOverride: "cli-ns",
+	}).Resolve("")
+
+	raw, err := got.ClientConfig().RawConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "prod", raw.CurrentContext)
+	require.Contains(t, raw.Contexts, "prod")
+	assert.Equal(t, "cli-ns", raw.Contexts["prod"].Namespace)
+}
+
+func TestClientConfig_EmptyKubeconfigIsError(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("HOME", t.TempDir())
+
+	got := target.NewResolver(target.Config{}).Resolve("")
+	cc := got.ClientConfig()
+	require.NotNil(t, cc)
+
+	ns, overridden, err := cc.Namespace()
+	require.NoError(t, err)
+	assert.True(t, overridden)
+	assert.Equal(t, "default", ns)
+
+	_, err = cc.ClientConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build kubernetes config")
+
+	_, err = cc.RawConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build kubernetes config")
+}
+
+func TestClientConfig_NilTarget(t *testing.T) {
+	t.Parallel()
+
+	var got *target.Target
+	cc := got.ClientConfig()
+	require.NotNil(t, cc)
+
+	ns, overridden, err := cc.Namespace()
+	require.NoError(t, err)
+	assert.True(t, overridden)
+	assert.Equal(t, "default", ns)
+
+	cfg, err := got.RESTConfig()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "failed to build kubernetes config")
+	assert.Contains(t, err.Error(), "target is nil")
+}

--- a/internal/target/doc.go
+++ b/internal/target/doc.go
@@ -26,10 +26,11 @@
 //  3. kubeconfig current-context
 //
 // [Target.Context] is the effective context name. [Target.ContextSource]
-// records which rule selected it. When Context is non-empty, [Target.RESTConfig]
-// pins that name so the destination cannot change after Resolve.
-// [Target.RESTConfig] uses the snapshotted kubeconfig loading rules and
-// does not select in-cluster configuration.
+// records which rule selected it. When Context is non-empty,
+// [Target.ClientConfig] and [Target.RESTConfig] pin that name so the
+// destination cannot change after Resolve. Both use the snapshotted
+// kubeconfig loading rules, pin [Target.Namespace], and do not select
+// in-cluster configuration.
 //
 // # Namespace precedence
 //

--- a/internal/target/doc.go
+++ b/internal/target/doc.go
@@ -27,10 +27,9 @@
 //
 // [Target.Context] is the effective context name. [Target.ContextSource]
 // records which rule selected it. When Context is non-empty,
-// [Target.ClientConfig] and [Target.RESTConfig] pin that name so the
-// destination cannot change after Resolve. Both use the snapshotted
-// kubeconfig loading rules, pin [Target.Namespace], and do not select
-// in-cluster configuration.
+// [Target.ClientConfig] and [Target.RESTConfig] pin that name. Both
+// use the snapshotted kubeconfig loading rules, pin [Target.Namespace],
+// and do not select in-cluster configuration.
 //
 // # Namespace precedence
 //
@@ -38,6 +37,7 @@
 //  2. namespace of the selected kubeconfig context
 //  3. "default"
 //
-// A resolved Target is immutable. Kubeconfig loading rules are snapshotted
-// at Resolve time so later KUBECONFIG or HOME changes do not retarget it.
+// Resolve pins context, source selection, and loading rules against
+// later KUBECONFIG or HOME changes. Kubeconfig file contents stay live
+// until configuration is loaded.
 package target

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -15,10 +15,7 @@
 package target
 
 import (
-	"fmt"
-
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // defaultNamespace is used when no override or kubeconfig context
@@ -41,7 +38,7 @@ const (
 //
 // After [Resolver.Resolve], Context, ContextSource, Namespace, and the
 // kubeconfig loading snapshot do not change. Concurrent calls to the
-// getters and [Target.RESTConfig] are safe.
+// getters, [Target.ClientConfig], and [Target.RESTConfig] are safe.
 type Target struct {
 	contextName   string
 	contextSource ContextSource
@@ -78,27 +75,12 @@ func (t *Target) Namespace() string {
 
 // RESTConfig returns a kubeconfig-based REST config for this destination.
 //
-// When Context is non-empty, the config pins that context. Loading rules
+// It uses [Target.ClientConfig]. When Context is non-empty, the config pins
+// that context. Namespace is pinned to [Target.Namespace]. Loading rules
 // come from the snapshot taken at Resolve, not from the current process
 // environment. It does not use in-cluster configuration. Load errors from
 // the snapshotted rules are returned; kubeconfig file contents are read at
 // call time.
 func (t *Target) RESTConfig() (*rest.Config, error) {
-	if t == nil {
-		return nil, fmt.Errorf("failed to build kubernetes config: target is nil")
-	}
-	rules := t.loading.clientConfigLoadingRules()
-	raw, err := rules.Load()
-	if err != nil {
-		return nil, fmt.Errorf("failed to build kubernetes config: %w", err)
-	}
-	overrides := &clientcmd.ConfigOverrides{}
-	if t.contextName != "" {
-		overrides.CurrentContext = t.contextName
-	}
-	cfg, err := clientcmd.NewNonInteractiveClientConfig(*raw, "", overrides, rules).ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to build kubernetes config: %w", err)
-	}
-	return cfg, nil
+	return t.ClientConfig().ClientConfig()
 }


### PR DESCRIPTION
## Summary

- Helm no longer picks a Kubernetes destination on its own (`cli.New()`, joined kubeconfig paths, or `HELM_*` kube overrides)
- Session passes `Target.ClientConfig()` into a Helm REST client getter, so extras, multi-file `KUBECONFIG`, context, and namespace match Target
- Offline `NewClient` / `RenderOffline` still works without a kubeconfig; a missing getter cannot fall back to ambient kubeconfig or in-cluster

## Related

Follows the Target destination work in #126.

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `nix run .#lint` / pre-commit clean
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore`
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [ ] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [ ] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`)
- [x] No secrets or local-only paths in the diff