### PR TITLE
return subst report from spec.Load

### DIFF
--- a/internal/action/deploy.go
+++ b/internal/action/deploy.go
@@ -16,7 +16,7 @@ type Deployer interface {
 
 // SpecLoader loads and validates a spec for an environment.
 type SpecLoader interface {
-	Spec(ctx context.Context, environment string) (*spec.Spec, error)
+	Spec(ctx context.Context, environment string) (*spec.Spec, spec.SubstitutionReport, error)
 }
 
 // Deploy encapsulates the deploy business logic.
@@ -33,11 +33,11 @@ func NewDeploy(deployer Deployer, loader SpecLoader) *Deploy {
 // Run loads the spec, resolves it for environment, and installs or upgrades
 // the Helm release.
 func (d *Deploy) Run(ctx context.Context, environment string, dryRun bool) (*spec.Spec, error) {
-	m, err := d.loader.Spec(ctx, environment)
+	m, substReport, err := d.loader.Spec(ctx, environment)
 	if err != nil {
 		return nil, fmt.Errorf("load spec: %w", err)
 	}
-	resolved, _, err := spec.Resolve(m, nil, spec.NormalizeEnv(environment), spec.SubstitutionReport{})
+	resolved, _, err := spec.Resolve(m, nil, spec.NormalizeEnv(environment), substReport)
 	if err != nil {
 		return nil, fmt.Errorf("resolve spec: %w", err)
 	}

--- a/internal/action/deploy_test.go
+++ b/internal/action/deploy_test.go
@@ -28,11 +28,11 @@ type mockSpecLoader struct {
 	err error
 }
 
-func (m *mockSpecLoader) Spec(_ context.Context, _ string) (*spec.Spec, error) {
+func (m *mockSpecLoader) Spec(_ context.Context, _ string) (*spec.Spec, spec.SubstitutionReport, error) {
 	if m.err != nil {
-		return nil, m.err
+		return nil, spec.SubstitutionReport{}, m.err
 	}
-	return m.m, nil
+	return m.m, spec.SubstitutionReport{}, nil
 }
 
 var testManifest = &spec.Spec{

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -91,23 +91,15 @@ func runDeploy(c *nabat.Context) error {
 	sess := session.FromContext(c)
 	ws := sess.Workspace()
 
-	// Prescan the raw (pre-envsubst) manifest for ${VAR} tokens so the
-	// resolver can distinguish static from dynamic subdomains.
-	rawSpec, rawErr := ws.ParseManifest()
-	if rawErr != nil {
-		return fmt.Errorf("parse manifest: %w", rawErr)
-	}
-	substReport := spec.PrescanSubstitutionReport(rawSpec)
-
 	// The platform file owns the environment registry --environment is
-	// validated against, so it loads before the spec.
+	// validated against, so it loads before the spec. The same pointer
+	// is passed to Load and Resolve so both see one platform state.
 	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		return fmt.Errorf("load platform file: %w", platformErr)
 	}
 
-	// Load the fully substituted manifest (envsubst applied).
-	manifest, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
+	manifest, substReport, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}

--- a/internal/cmd/initialize/summary_test.go
+++ b/internal/cmd/initialize/summary_test.go
@@ -87,7 +87,7 @@ func TestShowSummaryAndSave_RoleAwareComponentsProduceValidSpec(t *testing.T) {
 	assert.NotContains(t, body, "cpu:")
 	assert.NotContains(t, body, "memory:")
 
-	loaded, err := spec.Load(t.Context(), config.SpecPath, "", nil)
+	loaded, _, err := spec.Load(t.Context(), config.SpecPath, "", nil)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	assert.Equal(t, "shop", loaded.Project)
@@ -135,7 +135,7 @@ func TestShowSummaryAndSave_ServiceHealthCheckWithoutPortIsValid(t *testing.T) {
 	body := readSpecFile(t, config.SpecPath)
 	assert.NotContains(t, body, "port:")
 
-	loaded, err := spec.Load(t.Context(), config.SpecPath, "", nil)
+	loaded, _, err := spec.Load(t.Context(), config.SpecPath, "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, spec.DefaultServicePort, loaded.Components["web"].Port)
 }
@@ -419,7 +419,7 @@ func TestSparseSpec_RoundTripLoadFillsPort(t *testing.T) {
 	sparse := sparseSpec(config)
 	require.NoError(t, writeSpecFile(&sparse, config.SpecPath))
 
-	loaded, err := spec.Load(t.Context(), config.SpecPath, "", nil)
+	loaded, _, err := spec.Load(t.Context(), config.SpecPath, "", nil)
 	require.NoError(t, err)
 	require.NoError(t, spec.ValidateSpecComponents(loaded))
 	assert.Equal(t, spec.DefaultServicePort, loaded.Components["web"].Port)

--- a/internal/cmd/plan/plan.go
+++ b/internal/cmd/plan/plan.go
@@ -116,21 +116,12 @@ func runPlan(c *nabat.Context) error {
 	sess := session.FromContext(c)
 	ws := sess.Workspace()
 
-	// Prescan the raw (pre-envsubst) manifest for ${VAR} tokens so the
-	// resolver can distinguish static from dynamic subdomains, matching
-	// deploy's resolution behavior.
-	rawSpec, rawErr := ws.ParseManifest()
-	if rawErr != nil {
-		return fmt.Errorf("parse manifest: %w", rawErr)
-	}
-	substReport := spec.PrescanSubstitutionReport(rawSpec)
-
 	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		return fmt.Errorf("load platform file: %w", platformErr)
 	}
 
-	manifest, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
+	manifest, substReport, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}

--- a/internal/cmd/resolve/resolve.go
+++ b/internal/cmd/resolve/resolve.go
@@ -89,13 +89,6 @@ func runResolve(c *nabat.Context) error {
 		return fmt.Errorf("environment argument required; or pass --environments for an overview")
 	}
 
-	// Raw manifest is only for the substitution prescan. Resolution must
-	// see the substituted spec so ${...} in env and envFile match deploy.
-	rawSpec, err := ws.ParseManifest()
-	if err != nil {
-		return fmt.Errorf("load manifest: %w", err)
-	}
-
 	// Load platform (degraded when absent). It owns the environment registry.
 	platform, platformErr := ws.Platform()
 	if platformErr != nil {
@@ -108,9 +101,7 @@ func runResolve(c *nabat.Context) error {
 	// registry keys internally.
 	envIdentity := spec.NormalizeEnv(opts.Environment)
 
-	substReport := spec.PrescanSubstitutionReport(rawSpec)
-
-	manifest, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform, spec.AllowHookCycleForDisplay())
+	manifest, substReport, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform, spec.AllowHookCycleForDisplay())
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -86,12 +86,12 @@ func runTask(c *nabat.Context) error {
 		return fmt.Errorf("load platform file: %w", platformErr)
 	}
 
-	manifest, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
+	manifest, substReport, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}
 
-	rt, err := resolveRunTask(manifest, platform, opts.Environment, opts.Task)
+	rt, err := resolveRunTask(manifest, platform, opts.Environment, opts.Task, substReport)
 	if err != nil {
 		return err
 	}
@@ -167,13 +167,13 @@ func executeRun(c *nabat.Context, cs kubernetes.Interface, timeout time.Duration
 	return nil
 }
 
-func resolveRunTask(manifest *spec.Spec, platform *spec.PlatformConfig, environment, name string) (spec.ResolvedTask, error) {
+func resolveRunTask(manifest *spec.Spec, platform *spec.PlatformConfig, environment, name string, substReport spec.SubstitutionReport) (spec.ResolvedTask, error) {
 	envIdentity := spec.NormalizeEnv(environment)
 	// Run needs the task's resolved runtime/profile data, not component FQDNs.
 	// Display resolution allows runtime-only tasks to resolve when no platform
 	// file exists; spec.Load above still performs strict task-graph validation
 	// for run.
-	resolved, _, err := spec.ResolveForDisplay(manifest, platform, envIdentity, spec.SubstitutionReport{})
+	resolved, _, err := spec.ResolveForDisplay(manifest, platform, envIdentity, substReport)
 	if err != nil {
 		return spec.ResolvedTask{}, fmt.Errorf("resolve spec: %w", err)
 	}

--- a/internal/cmd/run/run_test.go
+++ b/internal/cmd/run/run_test.go
@@ -72,7 +72,7 @@ func TestResolveRunTask(t *testing.T) {
 
 	t.Run("merges from parent", func(t *testing.T) {
 		t.Parallel()
-		rt, err := resolveRunTask(m, nil, "dev", "migrate")
+		rt, err := resolveRunTask(m, nil, "dev", "migrate", spec.SubstitutionReport{})
 		require.NoError(t, err)
 		assert.Equal(t, "ghcr.io/acme/shop:1.2.3", rt.Task.Image)
 		assert.Equal(t, "postgres://db", rt.Runtime.ExplicitValues["DATABASE_URL"])
@@ -81,7 +81,7 @@ func TestResolveRunTask(t *testing.T) {
 
 	t.Run("scheduled task is runnable", func(t *testing.T) {
 		t.Parallel()
-		rt, err := resolveRunTask(m, nil, "dev", "cleanup")
+		rt, err := resolveRunTask(m, nil, "dev", "cleanup", spec.SubstitutionReport{})
 		require.NoError(t, err)
 		assert.Equal(t, spec.TaskOnSchedule, rt.Task.On)
 		assert.Equal(t, "0 3 * * *", rt.Task.Schedule)
@@ -94,7 +94,7 @@ func TestResolveRunTask(t *testing.T) {
 		api := local.Components["api"]
 		api.Profiles = []string{}
 		local.Components["api"] = api
-		rt, err := resolveRunTask(local, nil, "dev", "migrate")
+		rt, err := resolveRunTask(local, nil, "dev", "migrate", spec.SubstitutionReport{})
 		require.NoError(t, err)
 		assert.Equal(t, "ghcr.io/acme/shop:1.2.3", rt.Task.Image)
 	})
@@ -108,7 +108,7 @@ func TestResolveRunTask(t *testing.T) {
 		api := local.Components["api"]
 		api.Expose = &spec.Expose{Domain: "public"}
 		local.Components["api"] = api
-		rt, err := resolveRunTask(local, nil, "dev", "migrate")
+		rt, err := resolveRunTask(local, nil, "dev", "migrate", spec.SubstitutionReport{})
 		require.NoError(t, err)
 		assert.Equal(t, "postgres://db", rt.Runtime.ExplicitValues["DATABASE_URL"])
 		assert.Equal(t, "eu", rt.Runtime.FileValues["REGION"])
@@ -123,15 +123,15 @@ func TestResolveRunTask(t *testing.T) {
 				"prod": {Context: "kind"},
 			},
 		}
-		rt, err := resolveRunTask(m, platform, "dev", "migrate")
+		rt, err := resolveRunTask(m, platform, "dev", "migrate", spec.SubstitutionReport{})
 		require.NoError(t, err)
 		assert.Equal(t, "ghcr.io/acme/shop:1.2.3", rt.Task.Image)
 
-		_, err = resolveRunTask(m, platform, "dev", "backfill")
+		_, err = resolveRunTask(m, platform, "dev", "backfill", spec.SubstitutionReport{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "skipped")
 
-		_, err = resolveRunTask(m, platform, "dev", "missing")
+		_, err = resolveRunTask(m, platform, "dev", "missing", spec.SubstitutionReport{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "unknown task")
 	})
@@ -152,7 +152,7 @@ func TestResolveRunTask(t *testing.T) {
 				},
 			},
 		}
-		rt, err := resolveRunTask(local, nil, "dev", "migrate")
+		rt, err := resolveRunTask(local, nil, "dev", "migrate", spec.SubstitutionReport{})
 		require.NoError(t, err)
 		assert.Equal(t, "busybox", rt.Task.Image)
 		assert.Equal(t, []string{"echo", "ok"}, rt.Task.Command)
@@ -190,7 +190,7 @@ func TestResolveRunTask_Error(t *testing.T) {
 			api := m.Components["api"]
 			api.Profiles = tt.profiles
 			m.Components["api"] = api
-			_, err := resolveRunTask(m, nil, "dev", tt.task)
+			_, err := resolveRunTask(m, nil, "dev", tt.task, spec.SubstitutionReport{})
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tt.want)
 		})

--- a/internal/cmd/validate/validate.go
+++ b/internal/cmd/validate/validate.go
@@ -125,19 +125,12 @@ func runManifestOnly(c *nabat.Context, ws *workspace.Workspace) error {
 // the named environment. A missing platform file is allowed when the spec
 // does not use platform-owned features.
 func runCrossFile(c *nabat.Context, ws *workspace.Workspace, environment string) error {
-	rawSpec, err := ws.ParseManifest()
-	if err != nil {
-		return fmt.Errorf("manifest invalid: %w", err)
-	}
-
 	platform, platformErr := ws.Platform()
 	if platformErr != nil {
 		return fmt.Errorf("platform file error: %w", platformErr)
 	}
 
-	substReport := spec.PrescanSubstitutionReport(rawSpec)
-
-	loaded, err := spec.Load(c, ws.SpecPath(), environment, platform)
+	loaded, substReport, err := spec.Load(c, ws.SpecPath(), environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}

--- a/internal/spec/doc.go
+++ b/internal/spec/doc.go
@@ -20,7 +20,8 @@
 //
 // # Loading and saving
 //
-//   - [Load]: read a spec, resolve an environment, substitute variables
+//   - [Load]: read a spec, resolve an environment, substitute variables,
+//     and return a [SubstitutionReport] from that same file snapshot
 //   - [Save]: write a spec to YAML
 //
 // # Validation

--- a/internal/spec/example_test.go
+++ b/internal/spec/example_test.go
@@ -70,7 +70,7 @@ components:
 		log.Fatal(err)
 	}
 
-	m, err := spec.Load(context.Background(), path, "", nil)
+	m, _, err := spec.Load(context.Background(), path, "", nil)
 	if err != nil {
 		if rmErr := os.Remove(path); rmErr != nil {
 			log.Print(rmErr)

--- a/internal/spec/loader.go
+++ b/internal/spec/loader.go
@@ -146,9 +146,8 @@ func fileExists(path string) bool {
 
 // PrescanSubstitutionReport inspects the raw (pre-envsubst) spec for
 // ${VAR} tokens in expose.subdomain fields and returns a SubstitutionReport.
-// Call it after [ParseManifest] and before envsubst so the resolver can
-// distinguish static from dynamic subdomains (the wildcard static-subdomain
-// warning does not fire for dynamically expanded values).
+// [Load] computes the same report from the raw YAML map. Call this after
+// [ParseManifest] when a typed pre-substitution spec is already in hand.
 func PrescanSubstitutionReport(rawSpec *Spec) SubstitutionReport {
 	report := SubstitutionReport{DynamicSubdomains: make(map[string]bool)}
 	for name, comp := range rawSpec.Components {
@@ -159,6 +158,44 @@ func PrescanSubstitutionReport(rawSpec *Spec) SubstitutionReport {
 		}
 	}
 	return report
+}
+
+// prescanSubstitutionReportFromRaw records ${VAR} tokens in
+// components.*.expose.subdomain from the pre-substitution YAML map.
+// It is observational: malformed entries are skipped, not rejected.
+// expose: false and expose: true are skipped, matching
+// [normalizeComponents] / [PrescanSubstitutionReport].
+func prescanSubstitutionReportFromRaw(specObj map[string]any) SubstitutionReport {
+	report := SubstitutionReport{DynamicSubdomains: make(map[string]bool)}
+	if specObj == nil {
+		return report
+	}
+	components, ok := specObj["components"].(map[string]any)
+	if !ok {
+		return report
+	}
+	for name, raw := range components {
+		comp, isComp := raw.(map[string]any)
+		if !isComp {
+			continue
+		}
+		expose, isExpose := comp["expose"].(map[string]any)
+		if !isExpose {
+			continue
+		}
+		subdomain, isString := expose["subdomain"].(string)
+		if !isString {
+			continue
+		}
+		if varPattern.MatchString(subdomain) {
+			report.DynamicSubdomains[name] = true
+		}
+	}
+	return report
+}
+
+func loadFail(err error) (*Spec, SubstitutionReport, error) {
+	return nil, SubstitutionReport{}, err
 }
 
 // Save writes the spec to a YAML file at the specified path.
@@ -209,12 +246,18 @@ func AllowHookCycleForDisplay() LoadOption {
 // environment (using desiredEnv or default resolution rules), substitutes
 // variables according to precedence, validates the spec, and applies defaults.
 //
+// The returned [SubstitutionReport] is computed from the same
+// pre-substitution YAML map that Load already read. On success,
+// DynamicSubdomains is an initialized map (empty when no component used a
+// ${VAR} token in expose.subdomain). On any failure, Load returns a nil
+// spec, a zero [SubstitutionReport], and the error.
+//
 // platform supplies the environment registry for [ResolveEnvironment]; pass
 // nil when no platform file exists. This function performs the load pipeline
 // without platform resolution; for [ResolvedSpec] see [Resolve].
 //
 // opts may include [AllowHookCycleForDisplay] for inspect-only commands.
-func Load(ctx context.Context, path, desiredEnv string, platform *PlatformConfig, opts ...LoadOption) (*Spec, error) {
+func Load(ctx context.Context, path, desiredEnv string, platform *PlatformConfig, opts ...LoadOption) (*Spec, SubstitutionReport, error) {
 	options := loadOptions{}
 	for _, opt := range opts {
 		if opt != nil {
@@ -228,21 +271,23 @@ func Load(ctx context.Context, path, desiredEnv string, platform *PlatformConfig
 
 	data, err := os.ReadFile(path) // #nosec G304 -- spec path from CLI or default
 	if err != nil {
-		return nil, fmt.Errorf("failed to read spec: %w", err)
+		return loadFail(fmt.Errorf("failed to read spec: %w", err))
 	}
 
 	var specObj map[string]any
 	if err = yaml.Unmarshal(data, &specObj); err != nil {
-		return nil, fmt.Errorf("failed to parse spec YAML: %w", err)
+		return loadFail(fmt.Errorf("failed to parse spec YAML: %w", err))
 	}
+
+	substReport := prescanSubstitutionReportFromRaw(specObj)
 
 	version, err := ValidateAPIVersion(specObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate API version: %w", err)
+		return loadFail(fmt.Errorf("failed to validate API version: %w", err))
 	}
 
 	if err = ValidateEnvironments(specObj, version); err != nil {
-		return nil, fmt.Errorf("environments validation failed: %w", err)
+		return loadFail(fmt.Errorf("environments validation failed: %w", err))
 	}
 
 	// Parse the environments section to resolve the target environment.
@@ -250,56 +295,55 @@ func Load(ctx context.Context, path, desiredEnv string, platform *PlatformConfig
 		Environments map[string]Environment `yaml:"environments"`
 	}
 	if err = yaml.Unmarshal(data, &tmp); err != nil {
-		return nil, fmt.Errorf("failed to parse spec YAML: %w", err)
+		return loadFail(fmt.Errorf("failed to parse spec YAML: %w", err))
 	}
 
 	envName, env, err := ResolveEnvironment(tmp.Environments, platform, desiredEnv)
 	if err != nil {
-		return nil, fmt.Errorf("failed to select environment: %w", err)
+		return loadFail(fmt.Errorf("failed to select environment: %w", err))
 	}
 
 	slog.InfoContext(ctx, "selected environment", "environment", envName)
 
 	substituted, err := SubstituteVariables(data, env)
 	if err != nil {
-		return nil, fmt.Errorf("failed to substitute variables: %w", err)
+		return loadFail(fmt.Errorf("failed to substitute variables: %w", err))
 	}
 
 	var substitutedObj map[string]any
 	if err = yaml.Unmarshal(substituted, &substitutedObj); err != nil {
-		return nil, fmt.Errorf("failed to parse substituted spec YAML: %w", err)
+		return loadFail(fmt.Errorf("failed to parse substituted spec YAML: %w", err))
 	}
 
 	if err = ValidateSpec(substitutedObj, version); err != nil {
-		return nil, fmt.Errorf("spec validation failed: %w", err)
+		return loadFail(fmt.Errorf("spec validation failed: %w", err))
 	}
 
 	var finalSpec Spec
 	if err = yaml.Unmarshal(substituted, &finalSpec); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal spec: %w", err)
+		return loadFail(fmt.Errorf("failed to unmarshal spec: %w", err))
 	}
 	normalizeComponents(&finalSpec)
 
 	if err = ValidateSpecComponents(&finalSpec); err != nil {
-		return nil, fmt.Errorf("validation failed: %w", err)
+		return loadFail(fmt.Errorf("validation failed: %w", err))
 	}
 
 	if err = ValidateSpecTasks(&finalSpec, options.allowHookCycleForDisplay); err != nil {
-		return nil, fmt.Errorf("validation failed: %w", err)
+		return loadFail(fmt.Errorf("validation failed: %w", err))
 	}
 
 	if err = FillSpecWithDefaults(&finalSpec, version); err != nil {
-		return nil, fmt.Errorf("failed to apply defaults: %w", err)
+		return loadFail(fmt.Errorf("failed to apply defaults: %w", err))
 	}
 
 	finalSpec.SpecDir = filepath.Dir(path)
-	return &finalSpec, nil
+	return &finalSpec, substReport, nil
 }
 
 // ParseManifest reads and partially validates the spec YAML file: validates
 // the API version and environments section, then unmarshals the raw struct
 // without applying envsubst or defaults. It returns the raw spec and version.
-// Used by [Session.ResolvedSpec] as the first step of the full pipeline.
 func ParseManifest(path string) (*Spec, string, error) {
 	if path == "" {
 		path = DefaultSpecPath

--- a/internal/spec/loader_test.go
+++ b/internal/spec/loader_test.go
@@ -171,12 +171,14 @@ components:
 `
 	require.NoError(t, os.WriteFile(path, []byte(doc), 0o600))
 
-	m, err := Load(t.Context(), path, "", nil)
+	m, report, err := Load(t.Context(), path, "", nil)
 	require.NoError(t, err)
 	assert.Empty(t, m.Environments)
+	require.NotNil(t, report.DynamicSubdomains)
+	assert.Empty(t, report.DynamicSubdomains)
 
 	// An explicit free-form name is accepted when no registry exists.
-	m, err = Load(t.Context(), path, "qa", nil)
+	m, _, err = Load(t.Context(), path, "qa", nil)
 	require.NoError(t, err)
 	require.NotNil(t, m)
 }
@@ -265,7 +267,7 @@ environments:
 	require.NoError(t, os.WriteFile(filepath.Join(specDir, "deployah.yaml"), []byte(specYAML), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(specDir, ".env.dev"), []byte("DPY_VAR_IMAGE=ignored\n"), 0o600))
 
-	got, err := Load(t.Context(), filepath.Join(specDir, "deployah.yaml"), "dev", nil)
+	got, _, err := Load(t.Context(), filepath.Join(specDir, "deployah.yaml"), "dev", nil)
 	require.NoError(t, err)
 	require.Contains(t, got.Components, "web")
 	assert.Equal(t, "nginx:1.27", got.Components["web"].Image)
@@ -374,8 +376,10 @@ environments:
   production: {}
 `
 	require.NoError(t, os.WriteFile("deployah.yaml", []byte(content), 0o600))
-	_, err := Load(t.Context(), "deployah.yaml", "production", nil)
+	got, report, err := Load(t.Context(), "deployah.yaml", "production", nil)
 	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, SubstitutionReport{}, report)
 	assert.Contains(t, err.Error(), "profile")
 }
 
@@ -408,8 +412,10 @@ func TestLoad_HookCycleIsHardError(t *testing.T) {
 	path := filepath.Join(dir, "deployah.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(hookCycleSpecYAML), 0o600))
 
-	_, err := Load(t.Context(), path, "staging", nil)
+	got, report, err := Load(t.Context(), path, "staging", nil)
 	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, SubstitutionReport{}, report)
 	assert.ErrorContains(t, err, "cycle")
 }
 
@@ -420,7 +426,7 @@ func TestLoad_AllowHookCycleForDisplay_DefersCycle(t *testing.T) {
 	path := filepath.Join(dir, "deployah.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(hookCycleSpecYAML), 0o600))
 
-	got, err := Load(t.Context(), path, "staging", nil, AllowHookCycleForDisplay())
+	got, _, err := Load(t.Context(), path, "staging", nil, AllowHookCycleForDisplay())
 	require.NoError(t, err)
 	require.Contains(t, got.Tasks, "migrate")
 	require.Contains(t, got.Tasks, "seed")
@@ -447,7 +453,7 @@ environments:
 	path := filepath.Join(dir, "deployah.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(specYAML), 0o600))
 
-	got, err := Load(t.Context(), path, "staging", nil, AllowHookCycleForDisplay())
+	got, _, err := Load(t.Context(), path, "staging", nil, AllowHookCycleForDisplay())
 	require.NoError(t, err)
 	require.Contains(t, got.Tasks, "migrate")
 }
@@ -473,8 +479,10 @@ environments:
 	path := filepath.Join(dir, "deployah.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(specYAML), 0o600))
 
-	_, err := Load(t.Context(), path, "staging", nil, AllowHookCycleForDisplay())
+	got, report, err := Load(t.Context(), path, "staging", nil, AllowHookCycleForDisplay())
 	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, SubstitutionReport{}, report)
 	assert.ErrorContains(t, err, "does not name a task")
 }
 
@@ -503,7 +511,255 @@ environments:
 	path := filepath.Join(dir, "deployah.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(specYAML), 0o600))
 
-	_, err := Load(t.Context(), path, "staging", nil, AllowHookCycleForDisplay())
+	got, report, err := Load(t.Context(), path, "staging", nil, AllowHookCycleForDisplay())
 	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, SubstitutionReport{}, report)
 	assert.ErrorContains(t, err, "not in the same on phase")
+}
+
+const loadPrescanSpecYAML = `apiVersion: v1-alpha.5
+project: demo
+environments:
+  staging:
+    variables:
+      PREVIEW: pr-42
+      SNAPSHOT: from-first-read
+components:
+  web:
+    image: nginx:1.27
+    port: 8080
+    expose:
+      subdomain: ${PREVIEW}
+  api:
+    image: nginx:1.27
+    port: 8080
+    expose:
+      subdomain: api
+  hidden:
+    image: nginx:1.27
+    port: 8080
+    expose: false
+`
+
+// TestLoad_DetectsDynamicSubdomainWithoutParseManifest verifies Load
+// records ${VAR} tokens in expose.subdomain from the raw YAML map.
+func TestLoad_DetectsDynamicSubdomainWithoutParseManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deployah.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(loadPrescanSpecYAML), 0o600))
+
+	got, report, err := Load(t.Context(), path, "staging", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "pr-42", *got.Components["web"].Expose.Subdomain)
+	assert.Equal(t, "api", *got.Components["api"].Expose.Subdomain)
+	assert.Nil(t, got.Components["hidden"].Expose)
+	assert.Equal(t, map[string]bool{"web": true}, report.DynamicSubdomains)
+}
+
+// TestLoad_PrescanMatchesTypedPrescan verifies Load and
+// [ParseManifest]+[PrescanSubstitutionReport] agree on DynamicSubdomains
+// for the same file.
+func TestLoad_PrescanMatchesTypedPrescan(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deployah.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(loadPrescanSpecYAML), 0o600))
+
+	raw, _, err := ParseManifest(path)
+	require.NoError(t, err)
+	typed := PrescanSubstitutionReport(raw)
+
+	_, loaded, err := Load(t.Context(), path, "staging", nil)
+	require.NoError(t, err)
+	assert.Equal(t, typed.DynamicSubdomains, loaded.DynamicSubdomains)
+}
+
+// TestLoad_PrescanUsesFileSnapshot verifies the SubstitutionReport comes
+// from the same file bytes Load already read, not a later re-read.
+func TestLoad_PrescanUsesFileSnapshot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deployah.yaml")
+	original := `apiVersion: v1-alpha.5
+project: demo
+environments:
+  staging:
+    variables:
+      SNAPSHOT: from-first-read
+components:
+  web:
+    image: nginx:1.27
+    port: 8080
+    expose:
+      subdomain: ${SNAPSHOT}
+`
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600))
+
+	got, report, err := Load(t.Context(), path, "staging", nil)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{"web": true}, report.DynamicSubdomains)
+	assert.Equal(t, "from-first-read", *got.Components["web"].Expose.Subdomain)
+
+	overwritten := `apiVersion: v1-alpha.5
+project: demo
+environments:
+  staging: {}
+components:
+  web:
+    image: nginx:1.27
+    port: 8080
+    expose:
+      subdomain: static-name
+`
+	require.NoError(t, os.WriteFile(path, []byte(overwritten), 0o600))
+	assert.Equal(t, map[string]bool{"web": true}, report.DynamicSubdomains)
+	assert.Equal(t, "from-first-read", *got.Components["web"].Expose.Subdomain)
+}
+
+// TestLoad_FailureReturnsZeroReport verifies Load failures return a nil
+// spec and a zero SubstitutionReport. Empty contents means the file is
+// not created.
+func TestLoad_FailureReturnsZeroReport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "missing file"},
+		{name: "invalid yaml", contents: ":\n  -"},
+		{name: "invalid api version", contents: "apiVersion: nope\nproject: x\ncomponents: {}\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "deployah.yaml")
+			if tt.contents != "" {
+				require.NoError(t, os.WriteFile(path, []byte(tt.contents), 0o600))
+			}
+			got, report, err := Load(t.Context(), path, "staging", nil)
+			require.Error(t, err)
+			assert.Nil(t, got)
+			assert.Equal(t, SubstitutionReport{}, report)
+			assert.Nil(t, report.DynamicSubdomains)
+		})
+	}
+}
+
+// TestLoad_PrescanFeedsResolveDynamicNoWarning verifies a Load-produced
+// report skips the wildcard static-subdomain warning after substitution.
+func TestLoad_PrescanFeedsResolveDynamicNoWarning(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deployah.yaml")
+	doc := `apiVersion: v1-alpha.5
+project: shop
+environments:
+  review:
+    variables:
+      PR: pr-123
+components:
+  api:
+    image: nginx:1.27
+    port: 8080
+    expose:
+      domain: public
+      subdomain: ${PR}
+`
+	require.NoError(t, os.WriteFile(path, []byte(doc), 0o600))
+
+	platform := &PlatformConfig{
+		APIVersion: "platform/v1-alpha.3",
+		Environments: map[string]PlatformEnvironment{
+			"review": {
+				Context: "staging-eks",
+				Domains: map[string]PlatformDomain{
+					"public": {
+						BaseDomain: "review.example.com",
+						TLS:        &PlatformTLS{Mode: TLSModeSelfSigned},
+					},
+				},
+			},
+		},
+	}
+
+	manifest, substReport, err := Load(t.Context(), path, "review/pr-123", platform)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{"api": true}, substReport.DynamicSubdomains)
+
+	_, report, err := Resolve(manifest, platform, NormalizeEnv("review/pr-123"), substReport)
+	require.NoError(t, err)
+	assert.Empty(t, report.Warnings)
+}
+
+// TestPrescanSubstitutionReportFromRaw_SkipsNonMapExpose verifies the
+// raw-map prescan is observational and ignores bool or malformed expose.
+func TestPrescanSubstitutionReportFromRaw_SkipsNonMapExpose(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want map[string]bool
+	}{
+		{
+			name: "nil spec",
+			obj:  nil,
+			want: map[string]bool{},
+		},
+		{
+			name: "expose false",
+			obj: map[string]any{
+				"components": map[string]any{
+					"web": map[string]any{"expose": false},
+				},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "expose true",
+			obj: map[string]any{
+				"components": map[string]any{
+					"web": map[string]any{"expose": true},
+				},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "malformed component",
+			obj: map[string]any{
+				"components": map[string]any{
+					"web": "not-a-map",
+				},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "dynamic subdomain",
+			obj: map[string]any{
+				"components": map[string]any{
+					"web": map[string]any{
+						"expose": map[string]any{"subdomain": "${PREVIEW}"},
+					},
+				},
+			},
+			want: map[string]bool{"web": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := prescanSubstitutionReportFromRaw(tt.obj)
+			assert.Equal(t, tt.want, got.DynamicSubdomains)
+		})
+	}
 }

--- a/internal/testing/plan_scenarios.go
+++ b/internal/testing/plan_scenarios.go
@@ -230,14 +230,14 @@ func renderManifestFile(t *testing.T, dir, filename string) manifestSide {
 		platform = loaded
 	}
 
-	manifest, err := spec.Load(ctx, specPath, "", platform)
+	manifest, substReport, err := spec.Load(ctx, specPath, "", platform)
 	require.NoError(t, err)
 	envName, _, err := spec.ResolveEnvironment(manifest.Environments, platform, "")
 	require.NoError(t, err)
 
 	// Resolve even when platform is nil so runtime env reaches the chart.
 	envIdentity := spec.NormalizeEnv(envName)
-	resolved, _, resolveErr := spec.Resolve(manifest, platform, envIdentity, spec.SubstitutionReport{})
+	resolved, _, resolveErr := spec.Resolve(manifest, platform, envIdentity, substReport)
 	require.NoError(t, resolveErr)
 	require.NoError(t, k8s.MaterializeSelfSignedTLS(ctx, nil, "", resolved))
 

--- a/internal/testing/types.go
+++ b/internal/testing/types.go
@@ -207,7 +207,7 @@ func (suite *IntegrationTestSuite) loadAndResolve(t *testing.T, scenario TestSce
 		platform = loaded
 	}
 
-	manifest, err := spec.Load(ctx, scenario.ManifestFile, scenario.Environment, platform)
+	manifest, substReport, err := spec.Load(ctx, scenario.ManifestFile, scenario.Environment, platform)
 	if err != nil {
 		return nil, "", nil, platform, err
 	}
@@ -218,7 +218,7 @@ func (suite *IntegrationTestSuite) loadAndResolve(t *testing.T, scenario TestSce
 
 	// Resolve even when platform is nil so runtime env reaches the chart.
 	envIdentity := spec.NormalizeEnv(envName)
-	resolved, _, err := spec.Resolve(manifest, platform, envIdentity, spec.SubstitutionReport{})
+	resolved, _, err := spec.Resolve(manifest, platform, envIdentity, substReport)
 	if err != nil {
 		return nil, "", nil, platform, err
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -76,15 +76,16 @@ func (w *Workspace) ParseManifest() (*spec.Spec, error) {
 
 // LoadSpec loads the spec for environment from [Workspace.SpecPath] using
 // the Workspace platform and opts. Each call reads the spec from disk
-// because envsubst depends on environment.
-func (w *Workspace) LoadSpec(ctx context.Context, environment string, opts ...spec.LoadOption) (*spec.Spec, error) {
+// because envsubst depends on environment. The [spec.SubstitutionReport]
+// is the report produced by that [spec.Load] call.
+func (w *Workspace) LoadSpec(ctx context.Context, environment string, opts ...spec.LoadOption) (*spec.Spec, spec.SubstitutionReport, error) {
 	platform, err := w.Platform()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load platform file: %w", err)
+		return nil, spec.SubstitutionReport{}, fmt.Errorf("failed to load platform file: %w", err)
 	}
-	manifest, err := spec.Load(ctx, w.specPath, environment, platform, opts...)
+	manifest, report, err := spec.Load(ctx, w.specPath, environment, platform, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load spec: %w", err)
+		return nil, spec.SubstitutionReport{}, fmt.Errorf("failed to load spec: %w", err)
 	}
-	return manifest, nil
+	return manifest, report, nil
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -178,10 +178,11 @@ func TestLoadSpec_UsesWorkspacePlatform(t *testing.T) {
 		SpecPath:     specPath,
 		PlatformPath: platformPath,
 	})
-	got, err := w.LoadSpec(t.Context(), "production")
+	got, report, err := w.LoadSpec(t.Context(), "production")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "demo", got.Project)
+	require.NotNil(t, report.DynamicSubdomains)
 }
 
 func TestLoadSpec_OptionalMissingPlatform(t *testing.T) {
@@ -190,7 +191,7 @@ func TestLoadSpec_OptionalMissingPlatform(t *testing.T) {
 	writeFile(t, specPath, specWithStagingYAML)
 
 	w := workspace.New(workspace.Config{SpecPath: specPath})
-	got, err := w.LoadSpec(t.Context(), "staging")
+	got, _, err := w.LoadSpec(t.Context(), "staging")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "demo", got.Project)
@@ -206,9 +207,10 @@ func TestLoadSpec_RequiredPlatformFailure(t *testing.T) {
 		PlatformPath: filepath.Join(t.TempDir(), "missing.platform.yaml"),
 	})
 
-	got, err := w.LoadSpec(t.Context(), "staging")
+	got, report, err := w.LoadSpec(t.Context(), "staging")
 	require.Error(t, err)
 	assert.Nil(t, got)
+	assert.Equal(t, spec.SubstitutionReport{}, report)
 	assert.Contains(t, err.Error(), "failed to load platform file")
 	assert.NotContains(t, err.Error(), "failed to load spec")
 }
@@ -219,11 +221,12 @@ func TestLoadSpec_ForwardsLoadOption(t *testing.T) {
 	writeFile(t, specPath, hookCycleSpecYAML)
 	w := workspace.New(workspace.Config{SpecPath: specPath})
 
-	_, err := w.LoadSpec(t.Context(), "staging")
+	_, report, err := w.LoadSpec(t.Context(), "staging")
 	require.Error(t, err)
+	assert.Equal(t, spec.SubstitutionReport{}, report)
 	assert.Contains(t, err.Error(), "cycle")
 
-	got, err := w.LoadSpec(t.Context(), "staging", spec.AllowHookCycleForDisplay())
+	got, _, err := w.LoadSpec(t.Context(), "staging", spec.AllowHookCycleForDisplay())
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Contains(t, got.Tasks, "migrate")
@@ -254,7 +257,7 @@ func TestWorkspace_ConcurrentReads(t *testing.T) {
 			if _, err := w.ParseManifest(); err != nil {
 				t.Errorf("ParseManifest: %v", err)
 			}
-			if _, err := w.LoadSpec(ctx, "production"); err != nil {
+			if _, _, err := w.LoadSpec(ctx, "production"); err != nil {
 				t.Errorf("LoadSpec: %v", err)
 			}
 		})


### PR DESCRIPTION
## Summary

- `spec.Load` now returns a `SubstitutionReport` from the same raw YAML it already read, so callers no longer parse the file twice for a prescan.
- Deploy, plan, resolve, validate-with-env, and run pass one `Platform()` value into Load and Resolve, and use that Load-produced report.
- Testing helpers and `action.SpecLoader` carry the report with the loaded spec. `ParseManifest` stays for offline validate and `resolve --environments`.

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `nix run .#lint` / pre-commit clean
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/chore`
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [ ] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [ ] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`)
- [x] No secrets or local-only paths in the diff