### PR TITLE
add spec.ResolveTask for deployah run

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -86,12 +86,12 @@ func runTask(c *nabat.Context) error {
 		return fmt.Errorf("load platform file: %w", platformErr)
 	}
 
-	manifest, substReport, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
+	manifest, _, err := spec.Load(c, ws.SpecPath(), opts.Environment, platform)
 	if err != nil {
 		return fmt.Errorf("load spec: %w", err)
 	}
 
-	rt, err := resolveRunTask(manifest, platform, opts.Environment, opts.Task, substReport)
+	rt, err := spec.ResolveTask(manifest, platform, spec.NormalizeEnv(opts.Environment), opts.Task)
 	if err != nil {
 		return err
 	}
@@ -165,27 +165,4 @@ func executeRun(c *nabat.Context, cs kubernetes.Interface, timeout time.Duration
 	}
 	c.Success("Job completed", "name", created.Name)
 	return nil
-}
-
-func resolveRunTask(manifest *spec.Spec, platform *spec.PlatformConfig, environment, name string, substReport spec.SubstitutionReport) (spec.ResolvedTask, error) {
-	envIdentity := spec.NormalizeEnv(environment)
-	// Run needs the task's resolved runtime/profile data, not component FQDNs.
-	// Display resolution allows runtime-only tasks to resolve when no platform
-	// file exists; spec.Load above still performs strict task-graph validation
-	// for run.
-	resolved, _, err := spec.ResolveForDisplay(manifest, platform, envIdentity, substReport)
-	if err != nil {
-		return spec.ResolvedTask{}, fmt.Errorf("resolve spec: %w", err)
-	}
-	rt, ok := resolved.Tasks[name]
-	if !ok {
-		if _, exists := manifest.Tasks[name]; exists {
-			return spec.ResolvedTask{}, fmt.Errorf("task %s is skipped in environment %s", name, environment)
-		}
-		return spec.ResolvedTask{}, fmt.Errorf("unknown task %s", name)
-	}
-	if platform == nil && len(rt.Task.Profiles) > 0 {
-		return spec.ResolvedTask{}, fmt.Errorf("task %s sets profiles but no platform file was found", name)
-	}
-	return rt, nil
 }

--- a/internal/cmd/run/run_test.go
+++ b/internal/cmd/run/run_test.go
@@ -65,14 +65,14 @@ func testManifest() *spec.Spec {
 	}
 }
 
-func TestResolveRunTask(t *testing.T) {
+func TestResolveTask(t *testing.T) {
 	t.Parallel()
 
 	m := testManifest()
 
 	t.Run("merges from parent", func(t *testing.T) {
 		t.Parallel()
-		rt, err := resolveRunTask(m, nil, "dev", "migrate", spec.SubstitutionReport{})
+		rt, err := spec.ResolveTask(m, nil, spec.NormalizeEnv("dev"), "migrate")
 		require.NoError(t, err)
 		assert.Equal(t, "ghcr.io/acme/shop:1.2.3", rt.Task.Image)
 		assert.Equal(t, "postgres://db", rt.Runtime.ExplicitValues["DATABASE_URL"])
@@ -81,7 +81,7 @@ func TestResolveRunTask(t *testing.T) {
 
 	t.Run("scheduled task is runnable", func(t *testing.T) {
 		t.Parallel()
-		rt, err := resolveRunTask(m, nil, "dev", "cleanup", spec.SubstitutionReport{})
+		rt, err := spec.ResolveTask(m, nil, spec.NormalizeEnv("dev"), "cleanup")
 		require.NoError(t, err)
 		assert.Equal(t, spec.TaskOnSchedule, rt.Task.On)
 		assert.Equal(t, "0 3 * * *", rt.Task.Schedule)
@@ -94,7 +94,7 @@ func TestResolveRunTask(t *testing.T) {
 		api := local.Components["api"]
 		api.Profiles = []string{}
 		local.Components["api"] = api
-		rt, err := resolveRunTask(local, nil, "dev", "migrate", spec.SubstitutionReport{})
+		rt, err := spec.ResolveTask(local, nil, spec.NormalizeEnv("dev"), "migrate")
 		require.NoError(t, err)
 		assert.Equal(t, "ghcr.io/acme/shop:1.2.3", rt.Task.Image)
 	})
@@ -108,7 +108,7 @@ func TestResolveRunTask(t *testing.T) {
 		api := local.Components["api"]
 		api.Expose = &spec.Expose{Domain: "public"}
 		local.Components["api"] = api
-		rt, err := resolveRunTask(local, nil, "dev", "migrate", spec.SubstitutionReport{})
+		rt, err := spec.ResolveTask(local, nil, spec.NormalizeEnv("dev"), "migrate")
 		require.NoError(t, err)
 		assert.Equal(t, "postgres://db", rt.Runtime.ExplicitValues["DATABASE_URL"])
 		assert.Equal(t, "eu", rt.Runtime.FileValues["REGION"])
@@ -123,15 +123,15 @@ func TestResolveRunTask(t *testing.T) {
 				"prod": {Context: "kind"},
 			},
 		}
-		rt, err := resolveRunTask(m, platform, "dev", "migrate", spec.SubstitutionReport{})
+		rt, err := spec.ResolveTask(m, platform, spec.NormalizeEnv("dev"), "migrate")
 		require.NoError(t, err)
 		assert.Equal(t, "ghcr.io/acme/shop:1.2.3", rt.Task.Image)
 
-		_, err = resolveRunTask(m, platform, "dev", "backfill", spec.SubstitutionReport{})
+		_, err = spec.ResolveTask(m, platform, spec.NormalizeEnv("dev"), "backfill")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "skipped")
 
-		_, err = resolveRunTask(m, platform, "dev", "missing", spec.SubstitutionReport{})
+		_, err = spec.ResolveTask(m, platform, spec.NormalizeEnv("dev"), "missing")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "unknown task")
 	})
@@ -152,7 +152,7 @@ func TestResolveRunTask(t *testing.T) {
 				},
 			},
 		}
-		rt, err := resolveRunTask(local, nil, "dev", "migrate", spec.SubstitutionReport{})
+		rt, err := spec.ResolveTask(local, nil, spec.NormalizeEnv("dev"), "migrate")
 		require.NoError(t, err)
 		assert.Equal(t, "busybox", rt.Task.Image)
 		assert.Equal(t, []string{"echo", "ok"}, rt.Task.Command)
@@ -169,7 +169,7 @@ func TestResolveRunTask(t *testing.T) {
 	})
 }
 
-func TestResolveRunTask_Error(t *testing.T) {
+func TestResolveTask_Error(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -190,7 +190,7 @@ func TestResolveRunTask_Error(t *testing.T) {
 			api := m.Components["api"]
 			api.Profiles = tt.profiles
 			m.Components["api"] = api
-			_, err := resolveRunTask(m, nil, "dev", tt.task, spec.SubstitutionReport{})
+			_, err := spec.ResolveTask(m, nil, spec.NormalizeEnv("dev"), tt.task)
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tt.want)
 		})

--- a/internal/spec/doc.go
+++ b/internal/spec/doc.go
@@ -31,6 +31,13 @@
 //   - [ValidateSpecComponents]: check component resources and autoscaling
 //   - [ValidateSpecTasks]: check task names, from, on, after, schedule, and fanout
 //
+// # Resolution
+//
+//   - [Resolve]: join the loaded spec with platform policy for one environment
+//   - [ResolveForDisplay]: inspect-only resolve; missing platform and
+//     hook-cycle are warnings
+//   - [ResolveTask]: one named task for deployah run
+//
 // # Tasks
 //
 //   - [EffectiveTasks]: environment-scoped tasks from a spec or resolved result

--- a/internal/spec/resolve.go
+++ b/internal/spec/resolve.go
@@ -776,43 +776,20 @@ func resolveTasks(appSpec *Spec, env EnvIdentity, platform *PlatformConfig, plat
 			return err
 		}
 	}
-	var platformProfiles map[string]PlatformProfile
-	if platform != nil {
-		platformProfiles = platform.Profiles
-	}
 	for _, name := range appSpec.TaskNames() {
 		task, ok := appSpec.MergedTask(name)
 		if !ok || !task.activeInEnvironment(env.Original) {
 			continue
 		}
-		if len(task.Profiles) > 0 && platform == nil {
-			return &ResolutionError{
-				Code: ErrCodePlatformNotFound,
-				Message: fmt.Sprintf(
-					"task %q sets profiles but no platform file was found; "+
-						"pass --platform-file or create %s",
-					name, DefaultPlatformPath,
-				),
-			}
+		rt, taskErr := resolveTaskDeclaration(name, task, platform, platformEnv, weights[name])
+		if taskErr != nil {
+			return taskErr
 		}
-		profileNames, profErr := ResolveProfileNames(task.Profiles, platformProfiles)
-		if profErr != nil {
-			return fmt.Errorf("task %q: %w", name, profErr)
-		}
-		rt := ResolvedTask{Task: task, HookWeight: weights[name], Profiles: profileNames}
-		if len(profileNames) > 0 {
-			merged, mergeErr := MergeProfiles(profileNames, platformProfiles)
-			if mergeErr != nil {
-				return fmt.Errorf("task %q: %w", name, mergeErr)
-			}
-			rt.MergedProfile = &merged
-			if profileErr := ValidateProfile(taskProfileTarget(name, task), merged, platformEnv, ""); profileErr != nil {
-				return profileErr
-			}
+		if len(rt.Profiles) > 0 {
 			report.Fields = append(report.Fields, ResolvedField{
 				Component: name,
 				Path:      "profiles",
-				Value:     strings.Join(profileNames, ", "),
+				Value:     strings.Join(rt.Profiles, ", "),
 				Source:    "platform profiles (merged left to right)",
 			})
 		}
@@ -825,4 +802,46 @@ func resolveTasks(appSpec *Spec, env EnvIdentity, platform *PlatformConfig, plat
 		})
 	}
 	return nil
+}
+
+// resolveTaskDeclaration fills merged task fields, hook weight, and profiles.
+// It does not attach runtime or write [ResolutionReport] fields.
+func resolveTaskDeclaration(
+	name string,
+	task Task,
+	platform *PlatformConfig,
+	platformEnv *PlatformEnvironment,
+	hookWeight int,
+) (ResolvedTask, error) {
+	if len(task.Profiles) > 0 && platform == nil {
+		return ResolvedTask{}, &ResolutionError{
+			Code: ErrCodePlatformNotFound,
+			Message: fmt.Sprintf(
+				"task %q sets profiles but no platform file was found; "+
+					"pass --platform-file or create %s",
+				name, DefaultPlatformPath,
+			),
+		}
+	}
+	var platformProfiles map[string]PlatformProfile
+	if platform != nil {
+		platformProfiles = platform.Profiles
+	}
+	profileNames, err := ResolveProfileNames(task.Profiles, platformProfiles)
+	if err != nil {
+		return ResolvedTask{}, fmt.Errorf("task %q: %w", name, err)
+	}
+	rt := ResolvedTask{Task: task, HookWeight: hookWeight, Profiles: profileNames}
+	if len(profileNames) == 0 {
+		return rt, nil
+	}
+	merged, err := MergeProfiles(profileNames, platformProfiles)
+	if err != nil {
+		return ResolvedTask{}, fmt.Errorf("task %q: %w", name, err)
+	}
+	rt.MergedProfile = &merged
+	if profileErr := ValidateProfile(taskProfileTarget(name, task), merged, platformEnv, ""); profileErr != nil {
+		return ResolvedTask{}, profileErr
+	}
+	return rt, nil
 }

--- a/internal/spec/resolve_task.go
+++ b/internal/spec/resolve_task.go
@@ -1,0 +1,88 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing the License.
+
+package spec
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// ResolveTask resolves one named task for env. It returns a [ResolvedTask]
+// by value: merged task fields, [ResolvedTask.HookWeight] from
+// [AssignHookWeights], applied profiles, and that task's runtime environment.
+//
+// Other active components and tasks are not resolved. Component FQDNs
+// and unrelated runtime environments are out of scope.
+//
+// platform may be nil. Resolution fails with [ErrCodePlatformNotFound]
+// when the merged task applies profiles and no platform file is present.
+// [ResolveProfileNames] still runs when the merged profile list is empty,
+// so a platform default profile applies.
+//
+// Runtime inheritance uses the raw task's From, Env, and EnvFile.
+// Parent ExplicitValues are inherited. Parent entity dotenv is loaded
+// only when the task does not set envFile. An unused parent envFile is
+// not read merely because the parent component is active in env.
+// Environment-level runtime inputs still apply.
+//
+// It returns an error when the task is unknown, inactive in env, or
+// [AssignHookWeights] fails. Hook-cycle handling is strict.
+func ResolveTask(
+	appSpec *Spec,
+	platform *PlatformConfig,
+	env EnvIdentity,
+	name string,
+) (ResolvedTask, error) {
+	task, ok := appSpec.MergedTask(name)
+	if !ok {
+		return ResolvedTask{}, fmt.Errorf("unknown task %s", name)
+	}
+	if !task.activeInEnvironment(env.Original) {
+		return ResolvedTask{}, fmt.Errorf("task %s is skipped in environment %s", name, env.Original)
+	}
+
+	weights, err := AssignHookWeights(appSpec.Tasks)
+	if err != nil {
+		return ResolvedTask{}, err
+	}
+
+	rt, err := resolveTaskDeclaration(name, task, platform, matchingPlatformEnv(platform, env), weights[name])
+	if err != nil {
+		return ResolvedTask{}, err
+	}
+
+	resolved := &ResolvedSpec{
+		Spec:       appSpec,
+		Env:        env,
+		Components: map[string]ResolvedComponent{},
+		Tasks:      map[string]ResolvedTask{name: rt},
+	}
+	if attachErr := attachRuntimeEnvironments(appSpec, env, resolved, nil); attachErr != nil {
+		return ResolvedTask{}, attachErr
+	}
+	return resolved.Tasks[name], nil
+}
+
+func matchingPlatformEnv(platform *PlatformConfig, env EnvIdentity) *PlatformEnvironment {
+	if platform == nil {
+		return nil
+	}
+	keys := slices.Sorted(maps.Keys(platform.Environments))
+	if matched, ok := matchEnvKey(env.Original, keys); ok {
+		pe := platform.Environments[matched]
+		return &pe
+	}
+	return nil
+}

--- a/internal/spec/resolve_task_test.go
+++ b/internal/spec/resolve_task_test.go
@@ -1,0 +1,309 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing the License.
+
+package spec
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resolveTaskSpec(dir string) *Spec {
+	return &Spec{
+		APIVersion: CurrentManifestVersion,
+		Project:    "shop",
+		SpecDir:    dir,
+		Components: map[string]Component{
+			"api": {Image: "ghcr.io/acme/shop:1.2.3", Env: StringMap{"DATABASE_URL": "postgres://db"}},
+			"web": {Image: "ghcr.io/acme/web:1.0.0"},
+		},
+		Tasks: map[string]Task{
+			"migrate": {
+				From:    "api",
+				On:      TaskOnPreDeploy,
+				Command: []string{"migrate", "up"},
+			},
+			"cleanup": {
+				From:    "api",
+				On:      TaskOnManual,
+				Command: []string{"cleanup"},
+			},
+			"backfill": {
+				From:         "api",
+				On:           TaskOnManual,
+				Command:      []string{"backfill"},
+				Environments: []string{"prod"},
+			},
+		},
+	}
+}
+
+func resolveTaskPlatform() *PlatformConfig {
+	return &PlatformConfig{
+		APIVersion: "platform/v1-alpha.3",
+		Environments: map[string]PlatformEnvironment{
+			"dev": {
+				Context: "kind",
+				Domains: map[string]PlatformDomain{
+					"public": {
+						BaseDomain: "example.com",
+						TLS:        &PlatformTLS{Mode: TLSModeSelfSigned},
+					},
+				},
+			},
+		},
+	}
+}
+
+func requireResolutionCode(t *testing.T, err error, code string) {
+	t.Helper()
+	require.Error(t, err)
+	re, ok := errors.AsType[*ResolutionError](err)
+	require.True(t, ok, "ResolveTask error %v", err)
+	assert.Equal(t, code, re.Code)
+}
+
+func TestResolveTask_UnrelatedComponentMissingEnvFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	web := appSpec.Components["web"]
+	web.EnvFile = "missing.web.env"
+	appSpec.Components["web"] = web
+
+	rt, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "migrate")
+	require.NoError(t, err)
+	assert.Equal(t, "ghcr.io/acme/shop:1.2.3", rt.Task.Image)
+	assert.Equal(t, "postgres://db", rt.Runtime.ExplicitValues["DATABASE_URL"])
+}
+
+func TestResolveTask_UnrelatedTaskMissingEnvFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	cleanup := appSpec.Tasks["cleanup"]
+	cleanup.EnvFile = "missing.cleanup.env"
+	appSpec.Tasks["cleanup"] = cleanup
+
+	rt, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "migrate")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"migrate", "up"}, rt.Task.Command)
+}
+
+func TestResolveTask_UnrelatedComponentInvalidDomain(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	web := appSpec.Components["web"]
+	web.Expose = &Expose{Domain: "missing"}
+	appSpec.Components["web"] = web
+	platform := resolveTaskPlatform()
+
+	_, _, resolveErr := Resolve(appSpec, platform, NormalizeEnv("dev"), SubstitutionReport{})
+	require.Error(t, resolveErr)
+
+	rt, err := ResolveTask(appSpec, platform, NormalizeEnv("dev"), "migrate")
+	require.NoError(t, err)
+	assert.Equal(t, "ghcr.io/acme/shop:1.2.3", rt.Task.Image)
+}
+
+func TestResolveTask_ParentEnvFileInheritedMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	api := appSpec.Components["api"]
+	api.EnvFile = "missing.parent.env"
+	appSpec.Components["api"] = api
+
+	_, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "migrate")
+	requireResolutionCode(t, err, ErrCodeEnvFileNotFound)
+	assert.Contains(t, err.Error(), "parent api")
+}
+
+func TestResolveTask_ParentEnvFileOverriddenUnused(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	requireWrite(t, dir, "task.env", "TASK_ONLY=1\n")
+	appSpec := resolveTaskSpec(dir)
+	api := appSpec.Components["api"]
+	api.EnvFile = "missing.parent.env"
+	appSpec.Components["api"] = api
+	migrate := appSpec.Tasks["migrate"]
+	migrate.EnvFile = "task.env"
+	appSpec.Tasks["migrate"] = migrate
+
+	rt, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "migrate")
+	require.NoError(t, err)
+	assert.Equal(t, "1", rt.Runtime.FileValues["TASK_ONLY"])
+	assert.Equal(t, "postgres://db", rt.Runtime.ExplicitValues["DATABASE_URL"])
+}
+
+func TestResolveTask_EnvironmentLevelEnvFileMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	appSpec.Environments = map[string]Environment{
+		"dev": {EnvFile: "missing.env"},
+	}
+
+	_, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "migrate")
+	requireResolutionCode(t, err, ErrCodeEnvFileNotFound)
+}
+
+func TestResolveTask_ProfilesWithPlatformIgnoresUnrelatedDomain(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	web := appSpec.Components["web"]
+	web.Expose = &Expose{Domain: "missing"}
+	appSpec.Components["web"] = web
+	migrate := appSpec.Tasks["migrate"]
+	migrate.Profiles = []string{"batch"}
+	appSpec.Tasks["migrate"] = migrate
+
+	platform := resolveTaskPlatform()
+	platform.Profiles = map[string]PlatformProfile{
+		"batch": {NodeSelector: map[string]string{"workload": "batch"}},
+	}
+
+	rt, err := ResolveTask(appSpec, platform, NormalizeEnv("dev"), "migrate")
+	require.NoError(t, err)
+	require.NotNil(t, rt.MergedProfile)
+	assert.Equal(t, []string{"batch"}, rt.Profiles)
+	assert.Equal(t, "batch", rt.MergedProfile.NodeSelector["workload"])
+}
+
+func TestResolveTask_ProfilesWithoutPlatform(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	migrate := appSpec.Tasks["migrate"]
+	migrate.Profiles = []string{"batch"}
+	appSpec.Tasks["migrate"] = migrate
+
+	_, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "migrate")
+	requireResolutionCode(t, err, ErrCodePlatformNotFound)
+	assert.Contains(t, err.Error(), "no platform file")
+}
+
+func TestResolveTask_InactiveInEnvironment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	_, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "backfill")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "skipped")
+}
+
+func TestResolveTask_UnknownTask(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	_, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "missing")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unknown task")
+}
+
+func TestResolveTask_DefaultProfileWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	platform := resolveTaskPlatform()
+	platform.Profiles = map[string]PlatformProfile{
+		"default": {NodeSelector: map[string]string{"workload": "general"}},
+	}
+
+	rt, err := ResolveTask(appSpec, platform, NormalizeEnv("dev"), "migrate")
+	require.NoError(t, err)
+	require.NotNil(t, rt.MergedProfile)
+	assert.Equal(t, []string{"default"}, rt.Profiles)
+	assert.Equal(t, "general", rt.MergedProfile.NodeSelector["workload"])
+}
+
+func TestResolveTask_InheritsProfilesFromParent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	api := appSpec.Components["api"]
+	api.Profiles = []string{"batch"}
+	appSpec.Components["api"] = api
+
+	platform := resolveTaskPlatform()
+	platform.Profiles = map[string]PlatformProfile{
+		"default": {NodeSelector: map[string]string{"workload": "general"}},
+		"batch":   {PodLabels: map[string]string{"tier": "jobs"}},
+	}
+
+	rt, err := ResolveTask(appSpec, platform, NormalizeEnv("dev"), "migrate")
+	require.NoError(t, err)
+	require.NotNil(t, rt.MergedProfile)
+	assert.Equal(t, []string{"default", "batch"}, rt.Profiles)
+	assert.Equal(t, "general", rt.MergedProfile.NodeSelector["workload"])
+	assert.Equal(t, "jobs", rt.MergedProfile.PodLabels["tier"])
+	assert.Equal(t, []string{"batch"}, rt.Task.Profiles)
+}
+
+func TestResolveTask_InheritedProfileValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	api := appSpec.Components["api"]
+	api.Profiles = []string{"tight"}
+	appSpec.Components["api"] = api
+	migrate := appSpec.Tasks["migrate"]
+	migrate.Resources = Resources{CPU: MustQuantity("2000m")}
+	appSpec.Tasks["migrate"] = migrate
+
+	platform := resolveTaskPlatform()
+	platform.Profiles = map[string]PlatformProfile{
+		"tight": {MaxResources: &ProfileMaxResources{CPU: MustQuantity("1000m")}},
+	}
+
+	_, err := ResolveTask(appSpec, platform, NormalizeEnv("dev"), "migrate")
+	requireResolutionCode(t, err, ErrCodeProfileResourceExceeded)
+	assert.Contains(t, err.Error(), `task "migrate"`)
+}
+
+func TestResolveTask_NonZeroHookWeight(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	appSpec := resolveTaskSpec(dir)
+	appSpec.Tasks["seed"] = Task{
+		From:    "api",
+		On:      TaskOnPreDeploy,
+		After:   []string{"migrate"},
+		Command: []string{"seed"},
+	}
+
+	rt, err := ResolveTask(appSpec, nil, NormalizeEnv("dev"), "seed")
+	require.NoError(t, err)
+	assert.Equal(t, 1, rt.HookWeight)
+	assert.Equal(t, []string{"seed"}, rt.Task.Command)
+}


### PR DESCRIPTION
## Summary

- Add `spec.ResolveTask` so `deployah run` resolves only the named task, its parent runtime, and environment-level inputs
- Unrelated components and tasks no longer block the run
- `Resolve` and `ResolveForDisplay` stay whole-spec

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `nix run .#lint` / pre-commit clean
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] `kind/bug`
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [ ] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [x] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`)
- [x] No secrets or local-only paths in the diff