### PR TITLE
add helm release prep and deploy intent

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -40,8 +40,8 @@ var (
 	ErrReleaseAlreadyExists = errors.New("release already exists")
 	// ErrReleasePending is returned when a Helm release has an operation in progress.
 	//
-	// Only [Client.InstallApp] produces this sentinel, via a typed check of the
-	// newest revision's pending status (Status.IsPending) before upgrade.
+	// [PrepareRelease] and [Client.InstallApp] produce this sentinel via a typed
+	// check of the newest revision's pending status (Status.IsPending).
 	// [Client.wrapHelmError] does not classify Helm's plain pending messages, so
 	// other action paths (and a rare race after the pre-check) surface those as
 	// generic helm failures. Callers may match with [errors.Is].

--- a/internal/helm/manager.go
+++ b/internal/helm/manager.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package helm generates Helm charts from Deployah specs and drives
-// install, upgrade, list, and delete operations against a cluster.
-//
-// [PrepareChart] renders templates and values for an environment into a
-// caller-supplied [ChartCache]. [Client] wraps Helm v4 actions with
-// Deployah-specific release naming, labels, and a per-client [ChartCache].
-// Kubernetes destination comes from a caller-supplied REST client getter
-// via [NewRESTClientGetter]; [Client] does not select a kubeconfig itself.
-// Package init pins Helm's kube.ManagedFieldsManager to "deployah".
 package helm
+
+import "helm.sh/helm/v4/pkg/kube"
+
+// Pin Helm's SSA field manager once per process. Helm reads
+// kube.ManagedFieldsManager on apply; if it is empty it uses the
+// process basename, which differs between the CLI and tests. init
+// runs before NewClient, so parallel constructors only read the
+// global.
+func init() {
+	kube.ManagedFieldsManager = "deployah" //nolint:reassign // Helm field manager is process-global.
+}

--- a/internal/helm/manager_test.go
+++ b/internal/helm/manager_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"helm.sh/helm/v4/pkg/kube"
+)
+
+func TestManagedFieldsManager_PinnedAtInit(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "deployah", kube.ManagedFieldsManager)
+}
+
+// TestManagedFieldsManager_ParallelNewClient races many constructors against
+// the process-global field manager. NewClient must not write the global;
+// after concurrent Init the manager stays "deployah".
+func TestManagedFieldsManager_ParallelNewClient(t *testing.T) {
+	const n = 32
+	var g errgroup.Group
+	for range n {
+		g.Go(func() error {
+			_, err := NewClient(
+				WithStorageDriver("memory"),
+				WithNamespace("default"),
+			)
+			return err
+		})
+	}
+	require.NoError(t, g.Wait())
+	assert.Equal(t, "deployah", kube.ManagedFieldsManager)
+}

--- a/internal/helm/prepare.go
+++ b/internal/helm/prepare.go
@@ -29,6 +29,8 @@ import (
 var ErrNoDeployedRevision = errors.New("no deployed revision to upgrade from")
 
 // Operation is whether Helm would install or upgrade given release history.
+// The zero value is invalid; only [OperationInstall] and [OperationUpgrade]
+// are legal.
 type Operation int
 
 const (
@@ -99,22 +101,27 @@ func PrepareRelease(history []*v1.Release) (ReleasePrep, error) {
 		Operation:    OperationUpgrade,
 		Newest:       newest,
 		Current:      current,
-		ApplyMethod:  ApplyMethodFor(OperationUpgrade, newest.ApplyMethod),
+		ApplyMethod:  applyMethodFor(OperationUpgrade, newest.ApplyMethod),
 		NextRevision: newest.Version + 1,
 	}, nil
 }
 
-// ApplyMethodFor returns the apply method Helm would use. Install is always
+// applyMethodFor returns the apply method Helm would use. Install is always
 // SSA. Upgrade with Helm's "auto" ServerSideApply is SSA only when
 // newestApplyMethod is "ssa"; empty, "csa", and any other value are CSA.
-func ApplyMethodFor(op Operation, newestApplyMethod string) ApplyMethod {
-	if op == OperationInstall {
+// It panics if op is not [OperationInstall] or [OperationUpgrade].
+func applyMethodFor(op Operation, newestApplyMethod string) ApplyMethod {
+	switch op {
+	case OperationInstall:
 		return ApplyMethodSSA
+	case OperationUpgrade:
+		if newestApplyMethod == string(ApplyMethodSSA) {
+			return ApplyMethodSSA
+		}
+		return ApplyMethodCSA
+	default:
+		panic(fmt.Sprintf("invalid helm operation %d", op))
 	}
-	if newestApplyMethod == string(ApplyMethodSSA) {
-		return ApplyMethodSSA
-	}
-	return ApplyMethodCSA
 }
 
 // currentUpgradeBaseline returns Helm's current release for an upgrade:

--- a/internal/helm/prepare.go
+++ b/internal/helm/prepare.go
@@ -1,0 +1,151 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"errors"
+	"fmt"
+
+	"helm.sh/helm/v4/pkg/release/common"
+
+	v1 "helm.sh/helm/v4/pkg/release/v1"
+)
+
+// ErrNoDeployedRevision is returned by [PrepareRelease] when history exists
+// but Helm would not upgrade: the newest revision is not pending, no
+// revision is deployed, and the newest status is not failed or superseded.
+var ErrNoDeployedRevision = errors.New("no deployed revision to upgrade from")
+
+// Operation is whether Helm would install or upgrade given release history.
+type Operation int
+
+const (
+	// OperationInstall is a first install: no history exists.
+	OperationInstall Operation = iota + 1
+	// OperationUpgrade is an upgrade of an existing release, including a
+	// failed-only history with no deployed revision.
+	OperationUpgrade
+)
+
+// ApplyMethod is how Helm would apply Kubernetes resources.
+type ApplyMethod string
+
+const (
+	// ApplyMethodSSA is Helm server-side apply ("ssa").
+	ApplyMethodSSA ApplyMethod = "ssa"
+	// ApplyMethodCSA is Helm client-side apply ("csa").
+	ApplyMethodCSA ApplyMethod = "csa"
+)
+
+// ReleasePrep is the install-or-upgrade decision Helm's prepareUpgrade
+// would make from release history. Newest and Current can differ; callers
+// must use those releases' Version fields, not a generic revision.
+type ReleasePrep struct {
+	// Operation is install when history is empty, otherwise upgrade.
+	Operation Operation
+	// Newest is Helm's last revision (highest Version), or nil on install.
+	Newest *v1.Release
+	// Current is the upgrade manifest baseline, or nil on install.
+	Current *v1.Release
+	// ApplyMethod is SSA on install, otherwise derived from Newest.
+	ApplyMethod ApplyMethod
+	// NextRevision is 1 on install, otherwise Newest.Version+1.
+	NextRevision int
+}
+
+// PrepareRelease decides install vs upgrade from history, matching Helm
+// v4.3.0 prepareUpgrade. It does not mutate history.
+//
+// An empty or nil slice is an install. History-fetch errors such as
+// [ErrReleaseNotFound] stay at the caller: treat not-found as empty
+// history, then call PrepareRelease.
+//
+// It returns [ErrReleasePending] when the newest revision is pending, and
+// [ErrNoDeployedRevision] when Helm would refuse the upgrade.
+func PrepareRelease(history []*v1.Release) (ReleasePrep, error) {
+	newest := newestRelease(history)
+	if newest == nil {
+		return ReleasePrep{
+			Operation:    OperationInstall,
+			ApplyMethod:  ApplyMethodSSA,
+			NextRevision: 1,
+		}, nil
+	}
+	if newest.Info == nil {
+		return ReleasePrep{}, fmt.Errorf("newest revision %d has no status", newest.Version)
+	}
+	if newest.Info.Status.IsPending() {
+		return ReleasePrep{}, fmt.Errorf("revision %d: %w", newest.Version, ErrReleasePending)
+	}
+
+	current, err := currentUpgradeBaseline(history, newest)
+	if err != nil {
+		return ReleasePrep{}, err
+	}
+
+	return ReleasePrep{
+		Operation:    OperationUpgrade,
+		Newest:       newest,
+		Current:      current,
+		ApplyMethod:  ApplyMethodFor(OperationUpgrade, newest.ApplyMethod),
+		NextRevision: newest.Version + 1,
+	}, nil
+}
+
+// ApplyMethodFor returns the apply method Helm would use. Install is always
+// SSA. Upgrade with Helm's "auto" ServerSideApply is SSA only when
+// newestApplyMethod is "ssa"; empty, "csa", and any other value are CSA.
+func ApplyMethodFor(op Operation, newestApplyMethod string) ApplyMethod {
+	if op == OperationInstall {
+		return ApplyMethodSSA
+	}
+	if newestApplyMethod == string(ApplyMethodSSA) {
+		return ApplyMethodSSA
+	}
+	return ApplyMethodCSA
+}
+
+// currentUpgradeBaseline returns Helm's current release for an upgrade:
+// Newest when it is deployed; otherwise the highest-version deployed
+// revision; otherwise Newest when it is failed or superseded.
+func currentUpgradeBaseline(history []*v1.Release, newest *v1.Release) (*v1.Release, error) {
+	if newest.Info.Status == common.StatusDeployed {
+		return newest, nil
+	}
+	if deployed := newestDeployed(history); deployed != nil {
+		return deployed, nil
+	}
+	switch newest.Info.Status {
+	case common.StatusFailed, common.StatusSuperseded:
+		return newest, nil
+	default:
+		return nil, fmt.Errorf("newest revision %d is %s: %w", newest.Version, newest.Info.Status, ErrNoDeployedRevision)
+	}
+}
+
+// newestDeployed returns the highest-version deployed release, or nil.
+// It does not mutate history.
+func newestDeployed(history []*v1.Release) *v1.Release {
+	var best *v1.Release
+	for _, rel := range history {
+		if rel == nil || rel.Info == nil || rel.Info.Status != common.StatusDeployed {
+			continue
+		}
+		if best == nil || rel.Version > best.Version {
+			best = rel
+		}
+	}
+	return best
+}

--- a/internal/helm/prepare_test.go
+++ b/internal/helm/prepare_test.go
@@ -246,7 +246,15 @@ func TestApplyMethodFor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, ApplyMethodFor(tt.op, tt.newest))
+			assert.Equal(t, tt.want, applyMethodFor(tt.op, tt.newest))
 		})
 	}
+}
+
+func TestApplyMethodFor_InvalidOperationPanics(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		applyMethodFor(0, "ssa")
+	})
 }

--- a/internal/helm/prepare_test.go
+++ b/internal/helm/prepare_test.go
@@ -1,0 +1,252 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v4/pkg/release/common"
+
+	v1 "helm.sh/helm/v4/pkg/release/v1"
+)
+
+func prepRelease(version int, status common.Status, applyMethod string) *v1.Release {
+	return &v1.Release{
+		Name:        "web-production",
+		Version:     version,
+		ApplyMethod: applyMethod,
+		Info:        &v1.Info{Status: status},
+	}
+}
+
+func TestPrepareRelease(t *testing.T) {
+	t.Parallel()
+
+	deployed := prepRelease(4, common.StatusDeployed, string(ApplyMethodSSA))
+	failed := prepRelease(5, common.StatusFailed, string(ApplyMethodCSA))
+	superseded := prepRelease(5, common.StatusSuperseded, "")
+	olderDeployed := prepRelease(3, common.StatusDeployed, string(ApplyMethodSSA))
+	failedSSA := prepRelease(5, common.StatusFailed, string(ApplyMethodSSA))
+	deployedCSA := prepRelease(4, common.StatusDeployed, string(ApplyMethodCSA))
+
+	tests := []struct {
+		name    string
+		history []*v1.Release
+		want    ReleasePrep
+		wantErr error
+	}{
+		{
+			name:    "nil history is install",
+			history: nil,
+			want: ReleasePrep{
+				Operation:    OperationInstall,
+				ApplyMethod:  ApplyMethodSSA,
+				NextRevision: 1,
+			},
+		},
+		{
+			name:    "empty history is install",
+			history: []*v1.Release{},
+			want: ReleasePrep{
+				Operation:    OperationInstall,
+				ApplyMethod:  ApplyMethodSSA,
+				NextRevision: 1,
+			},
+		},
+		{
+			name:    "latest deployed is upgrade",
+			history: []*v1.Release{prepRelease(1, common.StatusSuperseded, ""), deployed},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       deployed,
+				Current:      deployed,
+				ApplyMethod:  ApplyMethodSSA,
+				NextRevision: 5,
+			},
+		},
+		{
+			name:    "unsorted history still picks highest version",
+			history: []*v1.Release{deployed, prepRelease(1, common.StatusSuperseded, ""), prepRelease(2, common.StatusSuperseded, "")},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       deployed,
+				Current:      deployed,
+				ApplyMethod:  ApplyMethodSSA,
+				NextRevision: 5,
+			},
+		},
+		{
+			name:    "pending-install latest",
+			history: []*v1.Release{prepRelease(1, common.StatusPendingInstall, "")},
+			wantErr: ErrReleasePending,
+		},
+		{
+			name:    "pending-upgrade latest",
+			history: []*v1.Release{olderDeployed, prepRelease(4, common.StatusPendingUpgrade, "")},
+			wantErr: ErrReleasePending,
+		},
+		{
+			name:    "pending-rollback latest",
+			history: []*v1.Release{olderDeployed, prepRelease(4, common.StatusPendingRollback, "")},
+			wantErr: ErrReleasePending,
+		},
+		{
+			name:    "failed newest with older deployed",
+			history: []*v1.Release{olderDeployed, failed},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       failed,
+				Current:      olderDeployed,
+				ApplyMethod:  ApplyMethodCSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "superseded newest with older deployed",
+			history: []*v1.Release{olderDeployed, superseded},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       superseded,
+				Current:      olderDeployed,
+				ApplyMethod:  ApplyMethodCSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "failed-only is upgrade not install",
+			history: []*v1.Release{failed},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       failed,
+				Current:      failed,
+				ApplyMethod:  ApplyMethodCSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "superseded-only is upgrade",
+			history: []*v1.Release{superseded},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       superseded,
+				Current:      superseded,
+				ApplyMethod:  ApplyMethodCSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "newest failed csa with deployed ssa uses newest",
+			history: []*v1.Release{deployed, failed},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       failed,
+				Current:      deployed,
+				ApplyMethod:  ApplyMethodCSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "newest failed ssa with deployed csa uses newest",
+			history: []*v1.Release{deployedCSA, failedSSA},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       failedSSA,
+				Current:      deployedCSA,
+				ApplyMethod:  ApplyMethodSSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "uninstalled-only is not install",
+			history: []*v1.Release{prepRelease(1, common.StatusUninstalled, "")},
+			wantErr: ErrNoDeployedRevision,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := PrepareRelease(tt.history)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Equal(t, ReleasePrep{}, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.Operation, got.Operation)
+			assert.Equal(t, tt.want.ApplyMethod, got.ApplyMethod)
+			assert.Equal(t, tt.want.NextRevision, got.NextRevision)
+			assert.Same(t, tt.want.Newest, got.Newest)
+			assert.Same(t, tt.want.Current, got.Current)
+		})
+	}
+}
+
+func TestPrepareRelease_DoesNotMutateHistory(t *testing.T) {
+	t.Parallel()
+
+	first := prepRelease(1, common.StatusDeployed, "")
+	second := prepRelease(2, common.StatusFailed, "")
+	history := []*v1.Release{first, second}
+	original := slices.Clone(history)
+
+	_, err := PrepareRelease(history)
+	require.NoError(t, err)
+	assert.Equal(t, original, history)
+	assert.Same(t, first, history[0])
+	assert.Same(t, second, history[1])
+}
+
+func TestPrepareRelease_PendingIsWrappable(t *testing.T) {
+	t.Parallel()
+
+	_, err := PrepareRelease([]*v1.Release{
+		prepRelease(1, common.StatusPendingUpgrade, ""),
+	})
+	require.Error(t, err)
+	wrapped := fmt.Errorf("history: %w", err)
+	assert.ErrorIs(t, wrapped, ErrReleasePending)
+}
+
+func TestApplyMethodFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		op     Operation
+		newest string
+		want   ApplyMethod
+	}{
+		{name: "install ignores ssa", op: OperationInstall, newest: "ssa", want: ApplyMethodSSA},
+		{name: "install ignores csa", op: OperationInstall, newest: "csa", want: ApplyMethodSSA},
+		{name: "install ignores empty", op: OperationInstall, newest: "", want: ApplyMethodSSA},
+		{name: "upgrade ssa", op: OperationUpgrade, newest: "ssa", want: ApplyMethodSSA},
+		{name: "upgrade csa", op: OperationUpgrade, newest: "csa", want: ApplyMethodCSA},
+		{name: "upgrade empty is csa", op: OperationUpgrade, newest: "", want: ApplyMethodCSA},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ApplyMethodFor(tt.op, tt.newest))
+		})
+	}
+}

--- a/internal/plan/doc.go
+++ b/internal/plan/doc.go
@@ -21,6 +21,8 @@
 // runs [github.com/homeport/dyff] field-by-field on resources present on
 // both sides. [Plan] is the resulting domain model, consumed by a text
 // renderer ([RenderText]) and a JSON renderer ([NewJSONDocument]).
+// [DeploymentIntent] holds the mutation and executability flags a deploy
+// would use.
 //
 // Rendering the chart itself lives on [deployah.dev/deployah/internal/helm.Client]
 // instead, since `deployah plan` and `deployah deploy` share that one

--- a/internal/plan/intent.go
+++ b/internal/plan/intent.go
@@ -1,0 +1,39 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import "deployah.dev/deployah/internal/extras"
+
+// DeploymentIntent is the mutation and executability flags a deploy would
+// use. Presentation flags such as output format are not part of intent.
+// The zero value is not a valid intent: CRDs is empty, which extras
+// rejects. Callers should use [DefaultDeploymentIntent].
+type DeploymentIntent struct {
+	// CRDs is how missing or existing CRDs are applied.
+	CRDs extras.Policy
+	// ResizeVolumes enables persistent volume claim expansion.
+	ResizeVolumes bool
+	// Reapply forces Helm to run even when the rendered spec is unchanged.
+	Reapply bool
+	// ForceHostnameChange allows a hostname change that would otherwise be
+	// blocked.
+	ForceHostnameChange bool
+}
+
+// DefaultDeploymentIntent returns the deploy defaults: create-only CRDs
+// and the boolean flags unset.
+func DefaultDeploymentIntent() DeploymentIntent {
+	return DeploymentIntent{CRDs: extras.PolicyCreate}
+}

--- a/internal/plan/intent_test.go
+++ b/internal/plan/intent_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"deployah.dev/deployah/internal/extras"
+)
+
+func TestDefaultDeploymentIntent(t *testing.T) {
+	t.Parallel()
+
+	got := DefaultDeploymentIntent()
+	assert.Equal(t, extras.PolicyCreate, got.CRDs)
+	assert.False(t, got.ResizeVolumes)
+	assert.False(t, got.Reapply)
+	assert.False(t, got.ForceHostnameChange)
+}
+
+func TestDeploymentIntent_ZeroValueCRDsEmpty(t *testing.T) {
+	t.Parallel()
+
+	var zero DeploymentIntent
+	assert.Equal(t, extras.Policy(""), zero.CRDs)
+	assert.NotEqual(t, extras.PolicyCreate, zero.CRDs)
+}
+
+// deploymentIntentFields is the allowed field set of [DeploymentIntent].
+// Converting DeploymentIntent to this type fails to compile if a
+// presentation field is added or CRDs is not extras.Policy.
+type deploymentIntentFields struct {
+	CRDs                extras.Policy
+	ResizeVolumes       bool
+	Reapply             bool
+	ForceHostnameChange bool
+}
+
+var _ = deploymentIntentFields(DeploymentIntent{})
+
+func TestDeploymentIntent_UsesExtrasPolicy(t *testing.T) {
+	t.Parallel()
+
+	got := deploymentIntentFields(DefaultDeploymentIntent())
+	assert.Equal(t, extras.PolicyCreate, got.CRDs)
+	assert.False(t, got.ResizeVolumes)
+	assert.False(t, got.Reapply)
+	assert.False(t, got.ForceHostnameChange)
+}


### PR DESCRIPTION
## Summary

- Pin Helm server-side apply field manager to deployah at helm package init, so CLI and tests share one manager.
- Add PrepareRelease and ReleasePrep to match Helm v4.3.0 prepareUpgrade: newest vs current, next revision, apply method from newest.
- Add plan.DeploymentIntent (CRD policy, resize, reapply, hostname force). Plan and deploy CLI flags are unchanged.

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] golangci-lint on `./internal/helm` and `./internal/plan`; pre-commit hooks passed on commit
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore` (`kind/chore`)
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [x] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [x] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`) (package godoc only; no CLI change)
- [x] No secrets or local-only paths in the diff