### PR TITLE
reject non-ssa helm release history

### DIFF
--- a/internal/helm/doc.go
+++ b/internal/helm/doc.go
@@ -21,4 +21,8 @@
 // Kubernetes destination comes from a caller-supplied REST client getter
 // via [NewRESTClientGetter]; [Client] does not select a kubeconfig itself.
 // Package init pins Helm's kube.ManagedFieldsManager to "deployah".
+//
+// Deployah is alpha. The first supported Helm apply semantics are
+// server-side apply (SSA). Client-side apply and legacy empty apply
+// methods are unsupported.
 package helm

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -40,8 +40,9 @@ var (
 	ErrReleaseAlreadyExists = errors.New("release already exists")
 	// ErrReleasePending is returned when a Helm release has an operation in progress.
 	//
-	// [PrepareRelease] and [Client.InstallApp] produce this sentinel via a typed
-	// check of the newest revision's pending status (Status.IsPending).
+	// [PrepareRelease] produces this sentinel via a typed check of the newest
+	// revision's pending status (Status.IsPending). [Client.InstallApp] and
+	// [Client.RenderManifests] both go through [PrepareRelease].
 	// [Client.wrapHelmError] does not classify Helm's plain pending messages, so
 	// other action paths (and a rare race after the pre-check) surface those as
 	// generic helm failures. Callers may match with [errors.Is].
@@ -189,21 +190,11 @@ func (c *Client) InstallApp(ctx context.Context, dryRun bool, resolved *spec.Res
 		return err
 	}
 
-	// Decide install vs upgrade (and reject pending) before preparing the
-	// chart so a stuck pending release fails without chart work.
-	// History.Max is ignored by Helm (see [Client.GetReleaseHistory]), so
-	// sort by Version after a successful lookup rather than trusting order.
-	history := action.NewHistory(c.config)
-	histRels, histErr := history.Run(releaseName)
-	upgradeExisting := histErr == nil
-	if upgradeExisting {
-		rels, convErr := releaserListToV1(histRels)
-		if convErr != nil {
-			return fmt.Errorf("failed to convert release history: %w", convErr)
-		}
-		if newest := newestRelease(rels); newest != nil && newest.Info != nil && newest.Info.Status.IsPending() {
-			return fmt.Errorf("release '%s': %w", releaseName, ErrReleasePending)
-		}
+	// Decide install vs upgrade (and reject pending or unsupported
+	// history) before preparing the chart so those failures skip chart work.
+	prep, err := c.lookupReleasePrep(releaseName)
+	if err != nil {
+		return err
 	}
 
 	chartPath, err := PrepareChart(ctx, resolved, c.chartCache)
@@ -229,26 +220,61 @@ func (c *Client) InstallApp(ctx context.Context, dryRun bool, resolved *spec.Res
 		return fmt.Errorf("failed to load chart: %w", err)
 	}
 
-	if !upgradeExisting {
-		// Not found -> install. For other history errors, proceed with install
-		// attempt as well.
-		install := action.NewInstall(c.config)
-		install.ReleaseName = releaseName
-		install.Namespace = c.Namespace()
-		install.CreateNamespace = true
-		install.Timeout = c.timeout
-		install.WaitStrategy = kube.StatusWatcherStrategy
-		install.RollbackOnFailure = true
-		install.Labels = labels
-		install.PostRenderer = postRenderer
-
+	switch prep.Operation {
+	case OperationInstall:
+		install := c.newInstallAction(releaseName, labels, postRenderer)
 		if _, runErr := install.RunWithContext(ctx, ch, values); runErr != nil {
 			return c.wrapHelmError("install", releaseName, runErr)
 		}
 		return nil
+	case OperationUpgrade:
+		upgrade := c.newUpgradeAction(labels, postRenderer)
+		if _, runErr := upgrade.RunWithContext(ctx, releaseName, ch, values); runErr != nil {
+			return c.wrapHelmError("upgrade", releaseName, runErr)
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid helm operation %d", prep.Operation)
 	}
+}
 
-	// Upgrade existing release
+// lookupReleasePrep loads complete Helm history and decides install
+// vs upgrade. Only [driver.ErrReleaseNotFound] is a fresh install.
+// Other history errors are wrapped with [Client.wrapHelmError] after that
+// decision. [PrepareRelease] errors keep the release name in the wrap.
+func (c *Client) lookupReleasePrep(releaseName string) (ReleasePrep, error) {
+	history := action.NewHistory(c.config)
+	histRels, histErr := history.Run(releaseName)
+	if histErr != nil && !errors.Is(histErr, driver.ErrReleaseNotFound) {
+		return ReleasePrep{}, c.wrapHelmError("history", releaseName, histErr)
+	}
+	prep, err := prepareReleaseFromHistory(histRels, histErr)
+	if err != nil {
+		return ReleasePrep{}, fmt.Errorf("release '%s': %w", releaseName, err)
+	}
+	return prep, nil
+}
+
+// newInstallAction returns an install action with Deployah SSA defaults.
+// ForceConflicts and TakeOwnership stay false (Helm zeros).
+func (c *Client) newInstallAction(releaseName string, labels map[string]string, postRenderer postrenderer.PostRenderer) *action.Install {
+	install := action.NewInstall(c.config)
+	install.ReleaseName = releaseName
+	install.Namespace = c.Namespace()
+	install.CreateNamespace = true
+	install.Timeout = c.timeout
+	install.WaitStrategy = kube.StatusWatcherStrategy
+	install.RollbackOnFailure = true
+	install.Labels = labels
+	install.PostRenderer = postRenderer
+	install.ServerSideApply = true
+	return install
+}
+
+// newUpgradeAction returns an upgrade action with Deployah SSA defaults.
+// ServerSideApply is "true", not Helm's "auto". ForceConflicts and
+// TakeOwnership stay false (Helm zeros).
+func (c *Client) newUpgradeAction(labels map[string]string, postRenderer postrenderer.PostRenderer) *action.Upgrade {
 	upgrade := action.NewUpgrade(c.config)
 	upgrade.Namespace = c.Namespace()
 	upgrade.Timeout = c.timeout
@@ -256,11 +282,8 @@ func (c *Client) InstallApp(ctx context.Context, dryRun bool, resolved *spec.Res
 	upgrade.WaitStrategy = kube.StatusWatcherStrategy
 	upgrade.Labels = labels
 	upgrade.PostRenderer = postRenderer
-	_, err = upgrade.RunWithContext(ctx, releaseName, ch, values)
-	if err != nil {
-		return c.wrapHelmError("upgrade", releaseName, err)
-	}
-	return nil
+	upgrade.ServerSideApply = "true"
+	return upgrade
 }
 
 // newestRelease returns the release with the highest Version, or nil when
@@ -441,7 +464,9 @@ func releaserListToV1(rs []release.Releaser) ([]*v1.Release, error) {
 // Typed Kubernetes and Helm storage errors are classified first. String
 // matching remains for Helm messages that still lack stable sentinels
 // (not-found, already-exists, connection failures). Pending releases are
-// rejected earlier by [Client.InstallApp] via Status.IsPending, not here.
+// rejected earlier by [PrepareRelease], which both [Client.InstallApp]
+// and [Client.RenderManifests] run before Helm actions. This wrapper
+// does not decide install vs upgrade.
 func (c *Client) wrapHelmError(operation, releaseName string, err error) error {
 	if errors.Is(err, driver.ErrReleaseNotFound) {
 		return fmt.Errorf("release '%s': %w: %w", releaseName, ErrReleaseNotFound, err)
@@ -468,7 +493,7 @@ func (c *Client) wrapHelmError(operation, releaseName string, err error) error {
 	// Helm still surfaces some conditions as plain strings only.
 	// Timeout/forbidden/unauthorized string arms are omitted because the
 	// typed checks above cover those Kubernetes cases. Pending is omitted
-	// because InstallApp rejects it with a typed Status.IsPending check.
+	// because PrepareRelease rejects it with a typed Status.IsPending check.
 	errMsg := err.Error()
 	switch {
 	case strings.Contains(errMsg, "not found"):

--- a/internal/helm/helm_error_test.go
+++ b/internal/helm/helm_error_test.go
@@ -118,7 +118,7 @@ func TestWrapHelmError_TypedClassification(t *testing.T) {
 			wantIs: ErrReleaseAlreadyExists,
 		},
 		{
-			// Pending is handled by InstallApp's typed Status.IsPending
+			// Pending is handled by PrepareRelease's typed Status.IsPending
 			// pre-check, not by string matching in wrapHelmError.
 			name:    "helm pending string falls through",
 			err:     errors.New("another operation (install/upgrade/rollback) is in progress"),

--- a/internal/helm/preflight_test.go
+++ b/internal/helm/preflight_test.go
@@ -1,0 +1,244 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/release/common"
+	"helm.sh/helm/v4/pkg/storage"
+	"helm.sh/helm/v4/pkg/storage/driver"
+
+	"deployah.dev/deployah/internal/spec"
+
+	chartcommon "helm.sh/helm/v4/pkg/chart/common"
+	chart "helm.sh/helm/v4/pkg/chart/v2"
+	kubefake "helm.sh/helm/v4/pkg/kube/fake"
+	v1 "helm.sh/helm/v4/pkg/release/v1"
+)
+
+func TestNewInstallAction_ServerSideApply(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{
+		config:    new(action.Configuration),
+		namespace: "default",
+		timeout:   time.Minute,
+	}
+	got := c.newInstallAction("web-production", nil, nil)
+	assert.True(t, got.ServerSideApply)
+	assert.False(t, got.ForceConflicts)
+	assert.False(t, got.TakeOwnership)
+}
+
+func TestNewUpgradeAction_ServerSideApply(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{
+		config:    new(action.Configuration),
+		namespace: "default",
+		timeout:   time.Minute,
+	}
+	got := c.newUpgradeAction(nil, nil)
+	assert.Equal(t, "true", got.ServerSideApply)
+	assert.False(t, got.ForceConflicts)
+	assert.False(t, got.TakeOwnership)
+}
+
+func TestInstallApp_RejectsUnsupportedCSAHistory(t *testing.T) {
+	t.Parallel()
+
+	c, cfg, resolved, releaseName := memoryHelmApp(t, "csa-app")
+	seedRelease(t, cfg, releaseName, 1, common.StatusDeployed, applyCSA)
+
+	err := c.InstallApp(t.Context(), false, resolved, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedReleaseApplyMethod)
+	assert.Equal(t, 1, historyLen(t, cfg, releaseName))
+}
+
+func TestRenderManifests_RejectsUnsupportedCSAHistory(t *testing.T) {
+	t.Parallel()
+
+	c, cfg, resolved, releaseName := memoryHelmApp(t, "csa-render")
+	seedRelease(t, cfg, releaseName, 1, common.StatusDeployed, applyCSA)
+
+	_, cleanup, err := c.RenderManifests(t.Context(), resolved, nil)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedReleaseApplyMethod)
+}
+
+func TestInstallApp_NewestSSACurrentCSAIsRejected(t *testing.T) {
+	t.Parallel()
+
+	c, cfg, resolved, releaseName := memoryHelmApp(t, "mixed-app")
+	seedRelease(t, cfg, releaseName, 1, common.StatusDeployed, applyCSA)
+	seedRelease(t, cfg, releaseName, 2, common.StatusFailed, applySSA)
+
+	err := c.InstallApp(t.Context(), false, resolved, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedReleaseApplyMethod)
+	assert.Equal(t, 2, historyLen(t, cfg, releaseName))
+}
+
+func TestRenderManifests_NewestSSACurrentCSAIsRejected(t *testing.T) {
+	t.Parallel()
+
+	c, cfg, resolved, releaseName := memoryHelmApp(t, "mixed-render")
+	seedRelease(t, cfg, releaseName, 1, common.StatusDeployed, applyCSA)
+	seedRelease(t, cfg, releaseName, 2, common.StatusFailed, applySSA)
+
+	_, cleanup, err := c.RenderManifests(t.Context(), resolved, nil)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedReleaseApplyMethod)
+}
+
+func TestInstallApp_HistoryErrorIsNotInstall(t *testing.T) {
+	t.Parallel()
+
+	histErr := errors.New("secrets list forbidden")
+	c, cfg, resolved, releaseName := memoryHelmApp(t, "rbac-app")
+	failing := &kubefake.FailingKubeClient{ConnectionError: histErr}
+	failing.Out = io.Discard
+	cfg.KubeClient = failing
+
+	err := c.InstallApp(t.Context(), false, resolved, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, histErr)
+	assert.NotErrorIs(t, err, ErrUnsupportedReleaseApplyMethod)
+	_, histLookupErr := cfg.Releases.History(releaseName)
+	assert.ErrorIs(t, histLookupErr, driver.ErrReleaseNotFound)
+}
+
+func TestRenderManifests_HistoryErrorIsNotInstall(t *testing.T) {
+	t.Parallel()
+
+	histErr := errors.New("secrets list forbidden")
+	c, cfg, resolved, releaseName := memoryHelmApp(t, "rbac-render")
+	failing := &kubefake.FailingKubeClient{ConnectionError: histErr}
+	failing.Out = io.Discard
+	cfg.KubeClient = failing
+
+	_, cleanup, err := c.RenderManifests(t.Context(), resolved, nil)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, histErr)
+	_, histLookupErr := cfg.Releases.History(releaseName)
+	assert.ErrorIs(t, histLookupErr, driver.ErrReleaseNotFound)
+}
+
+func TestInstallApp_MissingReleaseIsInstall(t *testing.T) {
+	t.Parallel()
+
+	c, cfg, resolved, releaseName := memoryHelmApp(t, "fresh-app")
+
+	require.NoError(t, c.InstallApp(t.Context(), false, resolved, nil))
+	assert.Equal(t, 1, historyLen(t, cfg, releaseName))
+	rel, err := cfg.Releases.Last(releaseName)
+	require.NoError(t, err)
+	v1rel, err := releaserToV1(rel)
+	require.NoError(t, err)
+	assert.Equal(t, applySSA, v1rel.ApplyMethod)
+}
+
+func TestRenderManifests_MissingReleaseIsInstall(t *testing.T) {
+	t.Parallel()
+
+	c, _, resolved, _ := memoryHelmApp(t, "fresh-render")
+
+	result, cleanup, err := c.RenderManifests(t.Context(), resolved, nil)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsUpgrade)
+	assert.Equal(t, 1, result.Revision)
+}
+
+func memoryHelmApp(t *testing.T, project string) (*Client, *action.Configuration, *spec.ResolvedSpec, string) {
+	t.Helper()
+
+	cfg := &action.Configuration{
+		Releases:     storage.Init(driver.NewMemory()),
+		KubeClient:   &kubefake.PrintingKubeClient{Out: io.Discard},
+		Capabilities: chartcommon.DefaultCapabilities.Copy(),
+	}
+	c := &Client{
+		config:     cfg,
+		namespace:  "default",
+		timeout:    time.Minute,
+		chartCache: NewChartCache(time.Hour),
+	}
+
+	manifest := &spec.Spec{
+		APIVersion: spec.CurrentManifestVersion,
+		Project:    project,
+		Components: map[string]spec.Component{"web": serviceComponent()},
+	}
+	require.NoError(t, spec.FillSpecWithDefaults(manifest, spec.CurrentManifestVersion))
+	resolved, _, err := spec.Resolve(manifest, nil, spec.NormalizeEnv("production"), spec.SubstitutionReport{})
+	require.NoError(t, err)
+	return c, cfg, resolved, GenerateReleaseName(project, "production")
+}
+
+func seedRelease(t *testing.T, cfg *action.Configuration, name string, version int, status common.Status, applyMethod string) {
+	t.Helper()
+
+	now := time.Now()
+	require.NoError(t, cfg.Releases.Create(&v1.Release{
+		Name: name,
+		Info: &v1.Info{
+			FirstDeployed: now,
+			LastDeployed:  now,
+			Status:        status,
+			Description:   string(status),
+		},
+		Chart: &chart.Chart{
+			Metadata: &chart.Metadata{
+				APIVersion: "v2",
+				Name:       "hello",
+				Version:    "0.1.0",
+			},
+			Templates: []*chartcommon.File{
+				{Name: "templates/hello", Data: []byte("hello: world")},
+			},
+		},
+		Version:     version,
+		Namespace:   "default",
+		ApplyMethod: applyMethod,
+	}))
+}
+
+func historyLen(t *testing.T, cfg *action.Configuration, name string) int {
+	t.Helper()
+	rels, err := cfg.Releases.History(name)
+	require.NoError(t, err)
+	return len(rels)
+}

--- a/internal/helm/prepare.go
+++ b/internal/helm/prepare.go
@@ -18,7 +18,9 @@ import (
 	"errors"
 	"fmt"
 
+	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/release/common"
+	"helm.sh/helm/v4/pkg/storage/driver"
 
 	v1 "helm.sh/helm/v4/pkg/release/v1"
 )
@@ -27,6 +29,11 @@ import (
 // but Helm would not upgrade: the newest revision is not pending, no
 // revision is deployed, and the newest status is not failed or superseded.
 var ErrNoDeployedRevision = errors.New("no deployed revision to upgrade from")
+
+// ErrUnsupportedReleaseApplyMethod is returned by [PrepareRelease] when an
+// upgrade history revision is not Helm server-side apply ("ssa").
+// Empty, "csa", and unknown apply methods are unsupported.
+var ErrUnsupportedReleaseApplyMethod = errors.New("unsupported release apply method")
 
 // Operation is whether Helm would install or upgrade given release history.
 // The zero value is invalid; only [OperationInstall] and [OperationUpgrade]
@@ -41,16 +48,6 @@ const (
 	OperationUpgrade
 )
 
-// ApplyMethod is how Helm would apply Kubernetes resources.
-type ApplyMethod string
-
-const (
-	// ApplyMethodSSA is Helm server-side apply ("ssa").
-	ApplyMethodSSA ApplyMethod = "ssa"
-	// ApplyMethodCSA is Helm client-side apply ("csa").
-	ApplyMethodCSA ApplyMethod = "csa"
-)
-
 // ReleasePrep is the install-or-upgrade decision Helm's prepareUpgrade
 // would make from release history. Newest and Current can differ; callers
 // must use those releases' Version fields, not a generic revision.
@@ -61,27 +58,28 @@ type ReleasePrep struct {
 	Newest *v1.Release
 	// Current is the upgrade manifest baseline, or nil on install.
 	Current *v1.Release
-	// ApplyMethod is SSA on install, otherwise derived from Newest.
-	ApplyMethod ApplyMethod
 	// NextRevision is 1 on install, otherwise Newest.Version+1.
 	NextRevision int
 }
 
-// PrepareRelease decides install vs upgrade from history, matching Helm
-// v4.3.0 prepareUpgrade. It does not mutate history.
+// PrepareRelease decides install vs upgrade from history. Newest,
+// Current, pending, failed or superseded, and NextRevision match Helm
+// v4.3.0 prepareUpgrade. Deployah also requires Helm server-side apply
+// on the checked revisions. It does not mutate history.
 //
 // An empty or nil slice is an install. History-fetch errors such as
-// [ErrReleaseNotFound] stay at the caller: treat not-found as empty
-// history, then call PrepareRelease.
+// [driver.ErrReleaseNotFound] stay at the caller: treat only that
+// sentinel as empty history, then call PrepareRelease.
 //
-// It returns [ErrReleasePending] when the newest revision is pending, and
-// [ErrNoDeployedRevision] when Helm would refuse the upgrade.
+// It returns [ErrReleasePending] when the newest revision is pending,
+// [ErrNoDeployedRevision] when Helm would refuse the upgrade, and
+// [ErrUnsupportedReleaseApplyMethod] when Newest, or Current when it is
+// a different revision, is not Helm server-side apply.
 func PrepareRelease(history []*v1.Release) (ReleasePrep, error) {
 	newest := newestRelease(history)
 	if newest == nil {
 		return ReleasePrep{
 			Operation:    OperationInstall,
-			ApplyMethod:  ApplyMethodSSA,
 			NextRevision: 1,
 		}, nil
 	}
@@ -96,32 +94,48 @@ func PrepareRelease(history []*v1.Release) (ReleasePrep, error) {
 	if err != nil {
 		return ReleasePrep{}, err
 	}
+	if applyErr := requireSupportedApplyMethod(newest); applyErr != nil {
+		return ReleasePrep{}, applyErr
+	}
+	if current != nil && current.Version != newest.Version {
+		if applyErr := requireSupportedApplyMethod(current); applyErr != nil {
+			return ReleasePrep{}, applyErr
+		}
+	}
 
 	return ReleasePrep{
 		Operation:    OperationUpgrade,
 		Newest:       newest,
 		Current:      current,
-		ApplyMethod:  applyMethodFor(OperationUpgrade, newest.ApplyMethod),
 		NextRevision: newest.Version + 1,
 	}, nil
 }
 
-// applyMethodFor returns the apply method Helm would use. Install is always
-// SSA. Upgrade with Helm's "auto" ServerSideApply is SSA only when
-// newestApplyMethod is "ssa"; empty, "csa", and any other value are CSA.
-// It panics if op is not [OperationInstall] or [OperationUpgrade].
-func applyMethodFor(op Operation, newestApplyMethod string) ApplyMethod {
-	switch op {
-	case OperationInstall:
-		return ApplyMethodSSA
-	case OperationUpgrade:
-		if newestApplyMethod == string(ApplyMethodSSA) {
-			return ApplyMethodSSA
-		}
-		return ApplyMethodCSA
-	default:
-		panic(fmt.Sprintf("invalid helm operation %d", op))
+// requireSupportedApplyMethod reports [ErrUnsupportedReleaseApplyMethod]
+// unless rel was applied with Helm server-side apply.
+func requireSupportedApplyMethod(rel *v1.Release) error {
+	if rel.ApplyMethod == string(v1.ApplyMethodServerSideApply) {
+		return nil
 	}
+	return fmt.Errorf("revision %d apply method %q: %w", rel.Version, rel.ApplyMethod, ErrUnsupportedReleaseApplyMethod)
+}
+
+// prepareReleaseFromHistory decides install vs upgrade from a Helm
+// History.Run result. Only [driver.ErrReleaseNotFound] is a fresh
+// install. Other errors are returned as-is. It does not call
+// [Client.wrapHelmError].
+func prepareReleaseFromHistory(histRels []release.Releaser, histErr error) (ReleasePrep, error) {
+	if errors.Is(histErr, driver.ErrReleaseNotFound) {
+		return PrepareRelease(nil)
+	}
+	if histErr != nil {
+		return ReleasePrep{}, histErr
+	}
+	rels, err := releaserListToV1(histRels)
+	if err != nil {
+		return ReleasePrep{}, fmt.Errorf("failed to convert release history: %w", err)
+	}
+	return PrepareRelease(rels)
 }
 
 // currentUpgradeBaseline returns Helm's current release for an upgrade:

--- a/internal/helm/prepare_test.go
+++ b/internal/helm/prepare_test.go
@@ -15,15 +15,25 @@
 package helm
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v4/pkg/release"
 	"helm.sh/helm/v4/pkg/release/common"
+	"helm.sh/helm/v4/pkg/storage/driver"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	v1 "helm.sh/helm/v4/pkg/release/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	applySSA = string(v1.ApplyMethodServerSideApply)
+	applyCSA = string(v1.ApplyMethodClientSideApply)
 )
 
 func prepRelease(version int, status common.Status, applyMethod string) *v1.Release {
@@ -38,12 +48,13 @@ func prepRelease(version int, status common.Status, applyMethod string) *v1.Rele
 func TestPrepareRelease(t *testing.T) {
 	t.Parallel()
 
-	deployed := prepRelease(4, common.StatusDeployed, string(ApplyMethodSSA))
-	failed := prepRelease(5, common.StatusFailed, string(ApplyMethodCSA))
-	superseded := prepRelease(5, common.StatusSuperseded, "")
-	olderDeployed := prepRelease(3, common.StatusDeployed, string(ApplyMethodSSA))
-	failedSSA := prepRelease(5, common.StatusFailed, string(ApplyMethodSSA))
-	deployedCSA := prepRelease(4, common.StatusDeployed, string(ApplyMethodCSA))
+	deployed := prepRelease(4, common.StatusDeployed, applySSA)
+	failedSSA := prepRelease(5, common.StatusFailed, applySSA)
+	failedCSA := prepRelease(5, common.StatusFailed, applyCSA)
+	supersededSSA := prepRelease(5, common.StatusSuperseded, applySSA)
+	supersededEmpty := prepRelease(5, common.StatusSuperseded, "")
+	olderDeployedSSA := prepRelease(3, common.StatusDeployed, applySSA)
+	olderDeployedCSA := prepRelease(4, common.StatusDeployed, applyCSA)
 
 	tests := []struct {
 		name    string
@@ -56,7 +67,6 @@ func TestPrepareRelease(t *testing.T) {
 			history: nil,
 			want: ReleasePrep{
 				Operation:    OperationInstall,
-				ApplyMethod:  ApplyMethodSSA,
 				NextRevision: 1,
 			},
 		},
@@ -65,29 +75,26 @@ func TestPrepareRelease(t *testing.T) {
 			history: []*v1.Release{},
 			want: ReleasePrep{
 				Operation:    OperationInstall,
-				ApplyMethod:  ApplyMethodSSA,
 				NextRevision: 1,
 			},
 		},
 		{
-			name:    "latest deployed is upgrade",
-			history: []*v1.Release{prepRelease(1, common.StatusSuperseded, ""), deployed},
+			name:    "latest deployed ssa is upgrade",
+			history: []*v1.Release{prepRelease(1, common.StatusSuperseded, applySSA), deployed},
 			want: ReleasePrep{
 				Operation:    OperationUpgrade,
 				Newest:       deployed,
 				Current:      deployed,
-				ApplyMethod:  ApplyMethodSSA,
 				NextRevision: 5,
 			},
 		},
 		{
 			name:    "unsorted history still picks highest version",
-			history: []*v1.Release{deployed, prepRelease(1, common.StatusSuperseded, ""), prepRelease(2, common.StatusSuperseded, "")},
+			history: []*v1.Release{deployed, prepRelease(1, common.StatusSuperseded, applySSA), prepRelease(2, common.StatusSuperseded, applySSA)},
 			want: ReleasePrep{
 				Operation:    OperationUpgrade,
 				Newest:       deployed,
 				Current:      deployed,
-				ApplyMethod:  ApplyMethodSSA,
 				NextRevision: 5,
 			},
 		},
@@ -98,83 +105,87 @@ func TestPrepareRelease(t *testing.T) {
 		},
 		{
 			name:    "pending-upgrade latest",
-			history: []*v1.Release{olderDeployed, prepRelease(4, common.StatusPendingUpgrade, "")},
+			history: []*v1.Release{olderDeployedSSA, prepRelease(4, common.StatusPendingUpgrade, applyCSA)},
 			wantErr: ErrReleasePending,
 		},
 		{
 			name:    "pending-rollback latest",
-			history: []*v1.Release{olderDeployed, prepRelease(4, common.StatusPendingRollback, "")},
+			history: []*v1.Release{olderDeployedSSA, prepRelease(4, common.StatusPendingRollback, applySSA)},
 			wantErr: ErrReleasePending,
 		},
 		{
-			name:    "failed newest with older deployed",
-			history: []*v1.Release{olderDeployed, failed},
-			want: ReleasePrep{
-				Operation:    OperationUpgrade,
-				Newest:       failed,
-				Current:      olderDeployed,
-				ApplyMethod:  ApplyMethodCSA,
-				NextRevision: 6,
-			},
-		},
-		{
-			name:    "superseded newest with older deployed",
-			history: []*v1.Release{olderDeployed, superseded},
-			want: ReleasePrep{
-				Operation:    OperationUpgrade,
-				Newest:       superseded,
-				Current:      olderDeployed,
-				ApplyMethod:  ApplyMethodCSA,
-				NextRevision: 6,
-			},
-		},
-		{
-			name:    "failed-only is upgrade not install",
-			history: []*v1.Release{failed},
-			want: ReleasePrep{
-				Operation:    OperationUpgrade,
-				Newest:       failed,
-				Current:      failed,
-				ApplyMethod:  ApplyMethodCSA,
-				NextRevision: 6,
-			},
-		},
-		{
-			name:    "superseded-only is upgrade",
-			history: []*v1.Release{superseded},
-			want: ReleasePrep{
-				Operation:    OperationUpgrade,
-				Newest:       superseded,
-				Current:      superseded,
-				ApplyMethod:  ApplyMethodCSA,
-				NextRevision: 6,
-			},
-		},
-		{
-			name:    "newest failed csa with deployed ssa uses newest",
-			history: []*v1.Release{deployed, failed},
-			want: ReleasePrep{
-				Operation:    OperationUpgrade,
-				Newest:       failed,
-				Current:      deployed,
-				ApplyMethod:  ApplyMethodCSA,
-				NextRevision: 6,
-			},
-		},
-		{
-			name:    "newest failed ssa with deployed csa uses newest",
-			history: []*v1.Release{deployedCSA, failedSSA},
+			name:    "failed newest ssa with older deployed ssa",
+			history: []*v1.Release{olderDeployedSSA, failedSSA},
 			want: ReleasePrep{
 				Operation:    OperationUpgrade,
 				Newest:       failedSSA,
-				Current:      deployedCSA,
-				ApplyMethod:  ApplyMethodSSA,
+				Current:      olderDeployedSSA,
 				NextRevision: 6,
 			},
 		},
 		{
+			name:    "superseded newest ssa with older deployed ssa",
+			history: []*v1.Release{olderDeployedSSA, supersededSSA},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       supersededSSA,
+				Current:      olderDeployedSSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "failed-only ssa is upgrade not install",
+			history: []*v1.Release{failedSSA},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       failedSSA,
+				Current:      failedSSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "superseded-only ssa is upgrade",
+			history: []*v1.Release{supersededSSA},
+			want: ReleasePrep{
+				Operation:    OperationUpgrade,
+				Newest:       supersededSSA,
+				Current:      supersededSSA,
+				NextRevision: 6,
+			},
+		},
+		{
+			name:    "superseded-only empty apply method is unsupported",
+			history: []*v1.Release{supersededEmpty},
+			wantErr: ErrUnsupportedReleaseApplyMethod,
+		},
+		{
+			name:    "newest deployed csa is unsupported",
+			history: []*v1.Release{prepRelease(1, common.StatusDeployed, applyCSA)},
+			wantErr: ErrUnsupportedReleaseApplyMethod,
+		},
+		{
+			name:    "newest deployed empty apply method is unsupported",
+			history: []*v1.Release{prepRelease(1, common.StatusDeployed, "")},
+			wantErr: ErrUnsupportedReleaseApplyMethod,
+		},
+		{
+			name:    "newest deployed unknown apply method is unsupported",
+			history: []*v1.Release{prepRelease(1, common.StatusDeployed, "json-merge")},
+			wantErr: ErrUnsupportedReleaseApplyMethod,
+		},
+		{
+			name:    "newest ssa with different current csa is unsupported",
+			history: []*v1.Release{olderDeployedCSA, failedSSA},
+			wantErr: ErrUnsupportedReleaseApplyMethod,
+		},
+		{
+			name:    "newest failed csa with deployed ssa is unsupported",
+			history: []*v1.Release{deployed, failedCSA},
+			wantErr: ErrUnsupportedReleaseApplyMethod,
+		},
+		{
 			name:    "uninstalled-only is not install",
-			history: []*v1.Release{prepRelease(1, common.StatusUninstalled, "")},
+			history: []*v1.Release{prepRelease(1, common.StatusUninstalled, applySSA)},
 			wantErr: ErrNoDeployedRevision,
 		},
 	}
@@ -192,7 +203,6 @@ func TestPrepareRelease(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want.Operation, got.Operation)
-			assert.Equal(t, tt.want.ApplyMethod, got.ApplyMethod)
 			assert.Equal(t, tt.want.NextRevision, got.NextRevision)
 			assert.Same(t, tt.want.Newest, got.Newest)
 			assert.Same(t, tt.want.Current, got.Current)
@@ -203,8 +213,8 @@ func TestPrepareRelease(t *testing.T) {
 func TestPrepareRelease_DoesNotMutateHistory(t *testing.T) {
 	t.Parallel()
 
-	first := prepRelease(1, common.StatusDeployed, "")
-	second := prepRelease(2, common.StatusFailed, "")
+	first := prepRelease(1, common.StatusDeployed, applySSA)
+	second := prepRelease(2, common.StatusFailed, applySSA)
 	history := []*v1.Release{first, second}
 	original := slices.Clone(history)
 
@@ -219,42 +229,83 @@ func TestPrepareRelease_PendingIsWrappable(t *testing.T) {
 	t.Parallel()
 
 	_, err := PrepareRelease([]*v1.Release{
-		prepRelease(1, common.StatusPendingUpgrade, ""),
+		prepRelease(1, common.StatusPendingUpgrade, applyCSA),
 	})
 	require.Error(t, err)
 	wrapped := fmt.Errorf("history: %w", err)
 	assert.ErrorIs(t, wrapped, ErrReleasePending)
 }
 
-func TestApplyMethodFor(t *testing.T) {
+func TestPrepareReleaseFromHistory(t *testing.T) {
 	t.Parallel()
 
+	deployed := prepRelease(1, common.StatusDeployed, applySSA)
+	storageErr := errors.New("secret storage unavailable")
+	stringNotFound := errors.New("release: not found")
+	k8sNotFound := apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "rel.v1")
+
 	tests := []struct {
-		name   string
-		op     Operation
-		newest string
-		want   ApplyMethod
+		name    string
+		rels    []*v1.Release
+		histErr error
+		wantOp  Operation
+		wantErr error
 	}{
-		{name: "install ignores ssa", op: OperationInstall, newest: "ssa", want: ApplyMethodSSA},
-		{name: "install ignores csa", op: OperationInstall, newest: "csa", want: ApplyMethodSSA},
-		{name: "install ignores empty", op: OperationInstall, newest: "", want: ApplyMethodSSA},
-		{name: "upgrade ssa", op: OperationUpgrade, newest: "ssa", want: ApplyMethodSSA},
-		{name: "upgrade csa", op: OperationUpgrade, newest: "csa", want: ApplyMethodCSA},
-		{name: "upgrade empty is csa", op: OperationUpgrade, newest: "", want: ApplyMethodCSA},
+		{
+			name:    "driver not found is install",
+			histErr: driver.ErrReleaseNotFound,
+			wantOp:  OperationInstall,
+		},
+		{
+			name:    "wrapped driver not found is install",
+			histErr: fmt.Errorf("history: %w", driver.ErrReleaseNotFound),
+			wantOp:  OperationInstall,
+		},
+		{
+			name:    "k8s not found is not install",
+			histErr: k8sNotFound,
+			wantErr: k8sNotFound,
+		},
+		{
+			name:    "not found string is not install",
+			histErr: stringNotFound,
+			wantErr: stringNotFound,
+		},
+		{
+			name:    "storage error is not install",
+			histErr: storageErr,
+			wantErr: storageErr,
+		},
+		{
+			name:   "ssa history is upgrade",
+			rels:   []*v1.Release{deployed},
+			wantOp: OperationUpgrade,
+		},
+		{
+			name:    "csa history is unsupported",
+			rels:    []*v1.Release{prepRelease(1, common.StatusDeployed, applyCSA)},
+			wantErr: ErrUnsupportedReleaseApplyMethod,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, applyMethodFor(tt.op, tt.newest))
+
+			var histRels []release.Releaser
+			for _, rel := range tt.rels {
+				histRels = append(histRels, rel)
+			}
+
+			got, err := prepareReleaseFromHistory(histRels, tt.histErr)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Equal(t, ReleasePrep{}, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOp, got.Operation)
 		})
 	}
-}
-
-func TestApplyMethodFor_InvalidOperationPanics(t *testing.T) {
-	t.Parallel()
-
-	assert.Panics(t, func() {
-		applyMethodFor(0, "ssa")
-	})
 }

--- a/internal/helm/render.go
+++ b/internal/helm/render.go
@@ -36,11 +36,18 @@ import (
 const offlineMonitorAPIVersion = "monitoring.coreos.com/v1"
 
 // RenderManifests renders the chart from [spec.ResolvedSpec] client-side,
-// matching [Client.InstallApp]. Upgrade dry-runs still check cluster
-// reachability. A nil or unresolved spec is an error. Callers must run
-// the returned cleanup func.
+// matching [Client.InstallApp]. It looks up complete release history
+// first, so the cluster must be reachable for both install and upgrade.
+// Use [Client.RenderOffline] when there is no Kubernetes API access. A
+// nil or unresolved spec is an error. Callers must run the returned
+// cleanup func.
 func (c *Client) RenderManifests(ctx context.Context, resolved *spec.ResolvedSpec, postRenderer postrenderer.PostRenderer) (result *render.RenderResult, cleanup func(), err error) {
 	releaseName, labels, err := releaseIdentity(resolved)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	prep, err := c.lookupReleasePrep(releaseName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -52,15 +59,14 @@ func (c *Client) RenderManifests(ctx context.Context, resolved *spec.ResolvedSpe
 
 	values := map[string]any{}
 
-	history := action.NewHistory(c.config)
-	history.Max = 1
-	if _, histErr := history.Run(releaseName); histErr != nil {
-		// Not found -> fresh install. Any other history error is treated
-		// the same way InstallApp does: fall through to an install attempt,
-		// which will surface a clearer error if something else is wrong.
+	switch prep.Operation {
+	case OperationInstall:
 		result, err = c.renderInstall(ctx, releaseName, ch, values, labels, postRenderer)
-	} else {
+	case OperationUpgrade:
 		result, err = c.renderUpgrade(ctx, releaseName, ch, values, labels, postRenderer)
+	default:
+		cleanup()
+		return nil, nil, fmt.Errorf("invalid helm operation %d", prep.Operation)
 	}
 	if err != nil {
 		cleanup()
@@ -163,14 +169,9 @@ func (c *Client) renderInstall(ctx context.Context, releaseName string, ch *char
 	// this render is done so only this call is affected.
 	defer restoreCapabilitiesForDryRun(c.config)()
 
-	install := action.NewInstall(c.config)
-	install.ReleaseName = releaseName
-	install.Namespace = c.Namespace()
-	install.CreateNamespace = true
+	install := c.newInstallAction(releaseName, labels, postRenderer)
 	install.DryRunStrategy = action.DryRunClient
 	install.DisableOpenAPIValidation = true
-	install.Labels = labels
-	install.PostRenderer = postRenderer
 	// DryRunClient resets Capabilities to DefaultCapabilities (built-in
 	// APIs only). Append the Prometheus Operator GV so chart templates
 	// gated on .Capabilities.APIVersions.Has still render offline.
@@ -202,12 +203,9 @@ func (c *Client) renderUpgrade(ctx context.Context, releaseName string, ch *char
 	// is a legitimate cache other calls should reuse.
 	defer restoreConfigForDryRun(c.config)()
 
-	upgrade := action.NewUpgrade(c.config)
-	upgrade.Namespace = c.Namespace()
+	upgrade := c.newUpgradeAction(labels, postRenderer)
 	upgrade.DryRunStrategy = action.DryRunClient
 	upgrade.DisableOpenAPIValidation = true
-	upgrade.Labels = labels
-	upgrade.PostRenderer = postRenderer
 
 	rel, runErr := upgrade.RunWithContext(ctx, releaseName, ch, values)
 	if runErr != nil {


### PR DESCRIPTION
## Summary

- Require Helm `ssa` on the newest stored revision, and on current when it is a different revision. CSA and empty apply method fail before install or upgrade.
- Share one history preflight for `InstallApp` and `RenderManifests`. Only Helm storage `ErrReleaseNotFound` is a fresh install; other history errors propagate.
- Set install and upgrade actions to explicit server-side apply (`true`), not Helm `auto`. Offline render is unchanged.

## Related

Refs #131

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `golangci-lint` on `./internal/helm`; pre-commit hooks passed on commit
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore` (`kind/chore`)
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [x] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [x] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`) (package godoc only; no CLI change)
- [x] No secrets or local-only paths in the diff