### PR TITLE
add helm resource predictor library

### DIFF
--- a/internal/e2e/e2e_predict_test.go
+++ b/internal/e2e/e2e_predict_test.go
@@ -1,0 +1,370 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v4/pkg/kube"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"deployah.dev/deployah/internal/helm"
+	"deployah.dev/deployah/internal/predict"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (s *E2ESuite) predictCluster(t *testing.T) predict.Cluster {
+	t.Helper()
+	cluster, err := predict.NewCluster(s.client.RESTConfig())
+	require.NoError(t, err)
+	return cluster
+}
+
+func (s *E2ESuite) kubeClients(t *testing.T) (*kubernetes.Clientset, dynamic.Interface) {
+	t.Helper()
+	cs, err := kubernetes.NewForConfig(s.client.RESTConfig())
+	require.NoError(t, err)
+	dyn, err := dynamic.NewForConfig(s.client.RESTConfig())
+	require.NoError(t, err)
+	return cs, dyn
+}
+
+func predictConfigMapYAML(name, namespace, value string) string {
+	return "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: " + name +
+		"\n  namespace: " + namespace + "\ndata:\n  key: " + value + "\n"
+}
+
+func applyJSON(t *testing.T, obj *unstructured.Unstructured) []byte {
+	t.Helper()
+	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	require.NoError(t, err)
+	return data
+}
+
+func ownedConfigMapUnstructured(name, namespace, release, value string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+			"labels": map[string]any{
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+			"annotations": map[string]any{
+				"meta.helm.sh/release-name":      release,
+				"meta.helm.sh/release-namespace": namespace,
+			},
+		},
+		"data": map[string]any{"key": value},
+	}}
+}
+
+func ssaApplyOwnedConfigMap(t *testing.T, dyn dynamic.Interface, obj *unstructured.Unstructured, fieldManager string) {
+	t.Helper()
+	gvr := corev1.SchemeGroupVersion.WithResource("configmaps")
+	_, err := dyn.Resource(gvr).Namespace(obj.GetNamespace()).Patch(
+		t.Context(), obj.GetName(), types.ApplyPatchType, applyJSON(t, obj), metav1.PatchOptions{
+			FieldManager:    fieldManager,
+			FieldValidation: metav1.FieldValidationStrict,
+		})
+	require.NoError(t, err)
+}
+
+func findPredictResult(t *testing.T, results []predict.Result, name string) predict.Result {
+	t.Helper()
+	for _, r := range results {
+		if r.Identity.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("Predict() missing result %q", name)
+	return predict.Result{}
+}
+
+func (s *E2ESuite) TestPredictSSACreate() {
+	t := s.T()
+	ns := fixtureNamespace("predict-ssa-create")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	cluster := s.predictCluster(t)
+	cs, _ := s.kubeClients(t)
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Desired:     predictConfigMapYAML("app", ns, "next"),
+	})
+	require.NoError(t, err)
+	got := findPredictResult(t, results, "app")
+	assert.Equal(t, predict.ActionCreate, got.Action)
+	require.NotNil(t, got.Predicted)
+	key, found, nestErr := unstructured.NestedString(got.Predicted.Object, "data", "key")
+	require.NoError(t, nestErr)
+	require.True(t, found)
+	assert.Equal(t, "next", key)
+
+	_, err = cs.CoreV1().ConfigMaps(ns).Get(t.Context(), "app", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "live object must still be missing after Predict: %v", err)
+}
+
+func (s *E2ESuite) TestPredictSSAUpdate() {
+	t := s.T()
+	ns := fixtureNamespace("predict-ssa-update")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	cs, dyn := s.kubeClients(t)
+	ssaApplyOwnedConfigMap(t, dyn, ownedConfigMapUnstructured("app", ns, "web", "live"), kube.ManagedFieldsManager)
+
+	cluster := s.predictCluster(t)
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Desired:     predictConfigMapYAML("app", ns, "next"),
+	})
+	require.NoError(t, err)
+	got := findPredictResult(t, results, "app")
+	assert.Equal(t, predict.ActionUpdate, got.Action)
+	require.NotNil(t, got.Predicted)
+	key, found, nestErr := unstructured.NestedString(got.Predicted.Object, "data", "key")
+	require.NoError(t, nestErr)
+	require.True(t, found)
+	assert.Equal(t, "next", key)
+
+	live, err := cs.CoreV1().ConfigMaps(ns).Get(t.Context(), "app", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "live", live.Data["key"])
+}
+
+func (s *E2ESuite) TestPredictSSAConflict() {
+	t := s.T()
+	ns := fixtureNamespace("predict-ssa-conflict")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	_, dyn := s.kubeClients(t)
+	ssaApplyOwnedConfigMap(t, dyn, ownedConfigMapUnstructured("app", ns, "web", "other"), "other-manager")
+
+	cluster := s.predictCluster(t)
+	_, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Desired:     predictConfigMapYAML("app", ns, "next"),
+	})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err), "Predict() = %v, want field-manager conflict", err)
+}
+
+func (s *E2ESuite) TestPredictAPIServerDefaulting() {
+	t := s.T()
+	ns := fixtureNamespace("predict-api-default")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	desired := `apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: ` + ns + `
+spec:
+  selector:
+    app: web
+  ports:
+  - port: 80
+`
+	cluster := s.predictCluster(t)
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Desired:     desired,
+	})
+	require.NoError(t, err)
+	got := findPredictResult(t, results, "svc")
+	require.NotNil(t, got.Predicted)
+	affinity, found, err := unstructured.NestedString(got.Predicted.Object, "spec", "sessionAffinity")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, string(corev1.ServiceAffinityNone), affinity)
+}
+
+func (s *E2ESuite) TestPredictExternalAnnotationPreserved() {
+	t := s.T()
+	ns := fixtureNamespace("predict-ext-anno")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	cs, dyn := s.kubeClients(t)
+	ssaApplyOwnedConfigMap(t, dyn, ownedConfigMapUnstructured("app", ns, "web", "live"), kube.ManagedFieldsManager)
+	live, err := cs.CoreV1().ConfigMaps(ns).Get(t.Context(), "app", metav1.GetOptions{})
+	require.NoError(t, err)
+	if live.Annotations == nil {
+		live.Annotations = map[string]string{}
+	}
+	live.Annotations["deployah.dev/external"] = "keep-me"
+	_, err = cs.CoreV1().ConfigMaps(ns).Update(t.Context(), live, metav1.UpdateOptions{
+		FieldManager: "external-annotator",
+	})
+	require.NoError(t, err)
+
+	cluster := s.predictCluster(t)
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Desired:     predictConfigMapYAML("app", ns, "next"),
+	})
+	require.NoError(t, err)
+	got := findPredictResult(t, results, "app")
+	require.NotNil(t, got.Predicted)
+	assert.Equal(t, "keep-me", got.Predicted.GetAnnotations()["deployah.dev/external"])
+}
+
+func (s *E2ESuite) TestPredictOwnedAdoption() {
+	t := s.T()
+	ns := fixtureNamespace("predict-adopt")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	_, dyn := s.kubeClients(t)
+	ssaApplyOwnedConfigMap(t, dyn, ownedConfigMapUnstructured("app", ns, "web", "live"), kube.ManagedFieldsManager)
+
+	cluster := s.predictCluster(t)
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Desired:     predictConfigMapYAML("app", ns, "next"),
+	})
+	require.NoError(t, err)
+	got := findPredictResult(t, results, "app")
+	assert.Equal(t, predict.ActionUpdate, got.Action)
+	assert.NotNil(t, got.Live)
+	assert.Empty(t, got.Limitation)
+}
+
+func (s *E2ESuite) TestPredictDryRunDelete() {
+	t := s.T()
+	ns := fixtureNamespace("predict-dry-delete")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	cs, _ := s.kubeClients(t)
+	_, err := cs.CoreV1().ConfigMaps(ns).Create(t.Context(), &corev1.ConfigMap{
+		Name:      "old",
+		Namespace: ns,
+		Data:      map[string]string{"key": "live"},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	cluster := s.predictCluster(t)
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationUpgrade,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Previous:    predictConfigMapYAML("old", ns, "prev"),
+		Desired:     predictConfigMapYAML("app", ns, "next"),
+	})
+	require.NoError(t, err)
+	got := findPredictResult(t, results, "old")
+	assert.Equal(t, predict.ActionDelete, got.Action)
+
+	live, err := cs.CoreV1().ConfigMaps(ns).Get(t.Context(), "old", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "live", live.Data["key"])
+}
+
+func (s *E2ESuite) TestPredictManagedFieldsMigration() {
+	t := s.T()
+	ns := fixtureNamespace("predict-mf-migrate")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	cs, _ := s.kubeClients(t)
+	created, err := cs.CoreV1().ConfigMaps(ns).Create(t.Context(), &corev1.ConfigMap{
+		Name:      "app",
+		Namespace: ns,
+		Labels:    map[string]string{"app.kubernetes.io/managed-by": "Helm"},
+		Annotations: map[string]string{
+			"meta.helm.sh/release-name":      "web",
+			"meta.helm.sh/release-namespace": ns,
+		},
+		Data: map[string]string{"key": "v1"},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	created.Data["key"] = "v2"
+	updated, err := cs.CoreV1().ConfigMaps(ns).Update(t.Context(), created, metav1.UpdateOptions{
+		FieldManager: kube.ManagedFieldsManager,
+	})
+	require.NoError(t, err)
+	before, err := json.Marshal(updated.ManagedFields)
+	require.NoError(t, err)
+
+	cluster := s.predictCluster(t)
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Desired:     predictConfigMapYAML("app", ns, "v2"),
+	})
+	require.NoError(t, err)
+	got := findPredictResult(t, results, "app")
+	assert.Equal(t, predict.LimitationManagedFieldsMigration, got.Limitation)
+	assert.Equal(t, predict.ActionUpdate, got.Action)
+
+	afterLive, err := cs.CoreV1().ConfigMaps(ns).Get(t.Context(), "app", metav1.GetOptions{})
+	require.NoError(t, err)
+	after, err := json.Marshal(afterLive.ManagedFields)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(before), string(after))
+}
+
+func (s *E2ESuite) TestPredictManagedFieldsSSAAdoption() {
+	t := s.T()
+	ns := fixtureNamespace("predict-mf-ssa")
+	s.createNamespace(t, ns)
+	t.Cleanup(func() { s.deleteNamespace(t, ns) })
+
+	_, dyn := s.kubeClients(t)
+	ssaApplyOwnedConfigMap(t, dyn, ownedConfigMapUnstructured("app", ns, "web", "live"), kube.ManagedFieldsManager)
+
+	cluster := s.predictCluster(t)
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   ns,
+		Desired:     predictConfigMapYAML("app", ns, "next"),
+	})
+	require.NoError(t, err)
+	got := findPredictResult(t, results, "app")
+	assert.Empty(t, got.Limitation)
+	assert.Equal(t, predict.ActionUpdate, got.Action)
+}

--- a/internal/predict/cluster.go
+++ b/internal/predict/cluster.go
@@ -1,0 +1,159 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"context"
+	"fmt"
+
+	"helm.sh/helm/v4/pkg/kube"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	memcached "k8s.io/client-go/discovery/cached/memory"
+)
+
+// Cluster is the Kubernetes surface [Predict] uses. The production
+// implementation dry-runs every write. Tests substitute a fake.
+type Cluster interface {
+	Get(ctx context.Context, id Identity) (*unstructured.Unstructured, error)
+	Apply(ctx context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	JSONPatch(ctx context.Context, id Identity, patch []byte) error
+	Delete(ctx context.Context, id Identity) error
+	Mapping(gvk schema.GroupVersionKind) (*meta.RESTMapping, error)
+}
+
+type restCluster struct {
+	dyn    dynamic.Interface
+	mapper meta.RESTMapper
+}
+
+var _ Cluster = (*restCluster)(nil)
+
+// NewCluster builds the production [Cluster] for cfg. Construction matches
+// the existing dynamic-client plus discovery REST-mapper stack. Apply,
+// JSONPatch, and Delete always send server dry-run.
+func NewCluster(cfg *rest.Config) (Cluster, error) {
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build dynamic client: %w", err)
+	}
+	disco, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build discovery client: %w", err)
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memcached.NewMemCacheClient(disco))
+	return newRESTCluster(dyn, mapper), nil
+}
+
+func newRESTCluster(dyn dynamic.Interface, mapper meta.RESTMapper) *restCluster {
+	return &restCluster{dyn: dyn, mapper: mapper}
+}
+
+func (c *restCluster) Get(ctx context.Context, id Identity) (*unstructured.Unstructured, error) {
+	ri, err := c.resource(id.GroupVersionKind(), id.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return ri.Get(ctx, id.Name, metav1.GetOptions{})
+}
+
+func (c *restCluster) Apply(ctx context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode object %s/%s %s: %w",
+			obj.GetNamespace(), obj.GetName(), obj.GroupVersionKind().String(), err)
+	}
+	ri, err := c.resource(obj.GroupVersionKind(), obj.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+	predicted, err := ri.Patch(ctx, obj.GetName(), types.ApplyPatchType, data, applyPatchOptions())
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("conflict occurred while applying object %s/%s %s: %w",
+				obj.GetNamespace(), obj.GetName(), obj.GroupVersionKind().String(), err)
+		}
+		return nil, fmt.Errorf("server-side apply failed for object %s/%s %s: %w",
+			obj.GetNamespace(), obj.GetName(), obj.GroupVersionKind().String(), err)
+	}
+	return predicted, nil
+}
+
+func (c *restCluster) JSONPatch(ctx context.Context, id Identity, patch []byte) error {
+	ri, err := c.resource(id.GroupVersionKind(), id.Namespace)
+	if err != nil {
+		return err
+	}
+	_, err = ri.Patch(ctx, id.Name, types.JSONPatchType, patch, jsonPatchOptions())
+	return err
+}
+
+func (c *restCluster) Delete(ctx context.Context, id Identity) error {
+	ri, err := c.resource(id.GroupVersionKind(), id.Namespace)
+	if err != nil {
+		return err
+	}
+	return ri.Delete(ctx, id.Name, deleteOptions())
+}
+
+func (c *restCluster) Mapping(gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	return c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+}
+
+func (c *restCluster) resource(gvk schema.GroupVersionKind, namespace string) (dynamic.ResourceInterface, error) {
+	mapping, err := c.Mapping(gvk)
+	if err != nil {
+		return nil, err
+	}
+	nri := c.dyn.Resource(mapping.Resource)
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		return nri.Namespace(namespace), nil
+	}
+	return nri, nil
+}
+
+func applyPatchOptions() metav1.PatchOptions {
+	return metav1.PatchOptions{
+		DryRun:          []string{metav1.DryRunAll},
+		FieldManager:    kube.ManagedFieldsManager,
+		Force:           new(false),
+		FieldValidation: metav1.FieldValidationStrict,
+	}
+}
+
+func jsonPatchOptions() metav1.PatchOptions {
+	return metav1.PatchOptions{
+		DryRun:          []string{metav1.DryRunAll},
+		FieldManager:    kube.ManagedFieldsManager,
+		FieldValidation: metav1.FieldValidationStrict,
+	}
+}
+
+func deleteOptions() metav1.DeleteOptions {
+	return metav1.DeleteOptions{
+		DryRun:            []string{metav1.DryRunAll},
+		PropagationPolicy: new(metav1.DeletePropagationBackground),
+	}
+}

--- a/internal/predict/cluster_test.go
+++ b/internal/predict/cluster_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v4/pkg/kube"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func interceptApplyJSON(client *dynamicfake.FakeDynamicClient) {
+	client.PrependReactor("patch", "configmaps", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(clienttesting.PatchActionImpl)
+		if !ok {
+			return false, nil, nil
+		}
+		if patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		obj := &unstructured.Unstructured{Object: map[string]any{}}
+		if err := json.Unmarshal(patchAction.GetPatch(), &obj.Object); err != nil {
+			return true, nil, err
+		}
+		obj.SetName(patchAction.GetName())
+		obj.SetNamespace(patchAction.GetNamespace())
+		return true, obj, nil
+	})
+}
+
+func testRESTCluster(t *testing.T) (*restCluster, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+	fakeClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	interceptApplyJSON(fakeClient)
+	mapper := testrestmapper.TestOnlyStaticRESTMapper(clientgoscheme.Scheme)
+	return newRESTCluster(fakeClient, mapper), fakeClient
+}
+
+func testConfigMap(name, namespace, value string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"data": map[string]any{"key": value},
+	}}
+}
+
+func TestRESTCluster_ApplyRequestShape(t *testing.T) {
+	t.Parallel()
+	cluster, fakeClient := testRESTCluster(t)
+	obj := testConfigMap("app", "prod", "next")
+
+	got, err := cluster.Apply(t.Context(), obj)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "app", got.GetName())
+	assert.Equal(t, "prod", got.GetNamespace())
+
+	patch := lastPatch(t, fakeClient)
+	assert.Equal(t, types.ApplyPatchType, patch.GetPatchType())
+	assert.Equal(t, "app", patch.GetName())
+	assert.Equal(t, "prod", patch.GetNamespace())
+	require.True(t, json.Valid(patch.GetPatch()), "apply body must be JSON")
+
+	opts := patch.GetPatchOptions()
+	assert.Equal(t, []string{metav1.DryRunAll}, opts.DryRun)
+	assert.Equal(t, kube.ManagedFieldsManager, opts.FieldManager)
+	require.NotNil(t, opts.Force)
+	assert.False(t, *opts.Force)
+	assert.Equal(t, metav1.FieldValidationStrict, opts.FieldValidation)
+}
+
+func TestRESTCluster_JSONPatchRequestShape(t *testing.T) {
+	t.Parallel()
+	cluster, fakeClient := testRESTCluster(t)
+	id := Identity{Version: "v1", Kind: "ConfigMap", Namespace: "prod", Name: "app"}
+	patchBody := []byte(`[{"op":"replace","path":"/metadata/managedFields","value":[]}]`)
+	require.NoError(t, fakeClient.Tracker().Add(testConfigMap("app", "prod", "live")))
+
+	require.NoError(t, cluster.JSONPatch(t.Context(), id, patchBody))
+
+	patch := lastPatch(t, fakeClient)
+	assert.Equal(t, types.JSONPatchType, patch.GetPatchType())
+	assert.Equal(t, patchBody, []byte(patch.GetPatch()))
+	opts := patch.GetPatchOptions()
+	assert.Equal(t, []string{metav1.DryRunAll}, opts.DryRun)
+	assert.Equal(t, kube.ManagedFieldsManager, opts.FieldManager)
+	assert.Nil(t, opts.Force)
+	assert.Equal(t, metav1.FieldValidationStrict, opts.FieldValidation)
+}
+
+func TestRESTCluster_DeleteRequestShape(t *testing.T) {
+	t.Parallel()
+	cluster, fakeClient := testRESTCluster(t)
+	id := Identity{Version: "v1", Kind: "ConfigMap", Namespace: "prod", Name: "app"}
+
+	// Seed so the fake tracker can delete.
+	require.NoError(t, fakeClient.Tracker().Add(testConfigMap("app", "prod", "live")))
+	require.NoError(t, cluster.Delete(t.Context(), id))
+
+	var del clienttesting.DeleteActionImpl
+	found := false
+	for _, action := range fakeClient.Actions() {
+		if d, ok := action.(clienttesting.DeleteActionImpl); ok {
+			del = d
+			found = true
+		}
+	}
+	require.True(t, found, "expected a delete action")
+	assert.Equal(t, []string{metav1.DryRunAll}, del.DeleteOptions.DryRun)
+	require.NotNil(t, del.DeleteOptions.PropagationPolicy)
+	assert.Equal(t, metav1.DeletePropagationBackground, *del.DeleteOptions.PropagationPolicy)
+	assert.Nil(t, del.DeleteOptions.Preconditions)
+	assert.Nil(t, del.DeleteOptions.GracePeriodSeconds)
+}
+
+func lastPatch(t *testing.T, fakeClient *dynamicfake.FakeDynamicClient) clienttesting.PatchActionImpl {
+	t.Helper()
+	for _, action := range slices.Backward(fakeClient.Actions()) {
+		if p, ok := action.(clienttesting.PatchActionImpl); ok {
+			return p
+		}
+	}
+	t.Fatal("expected a patch action")
+	return clienttesting.PatchActionImpl{}
+}

--- a/internal/predict/delete.go
+++ b/internal/predict/delete.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"helm.sh/helm/v4/pkg/kube"
+	"k8s.io/client-go/util/retry"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -42,7 +43,10 @@ func predictPrune(ctx context.Context, cluster Cluster, previous resourceObj) (R
 			Predicted: live.DeepCopy(),
 		}, nil
 	}
-	if delErr := cluster.Delete(ctx, previous.id); delErr != nil {
+	delErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return cluster.Delete(ctx, previous.id)
+	})
+	if delErr != nil && !apierrors.IsNotFound(delErr) {
 		return Result{}, fmt.Errorf(
 			"failed to delete resource namespace=%s, name=%s, kind=%s: %w",
 			previous.id.Namespace, previous.id.Name, previous.id.Kind, delErr)

--- a/internal/predict/delete.go
+++ b/internal/predict/delete.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"context"
+	"fmt"
+
+	"helm.sh/helm/v4/pkg/kube"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func predictPrune(ctx context.Context, cluster Cluster, previous resourceObj) (Result, error) {
+	live, err := cluster.Get(ctx, previous.id)
+	if apierrors.IsNotFound(err) {
+		return Result{Identity: previous.id, Action: ActionNoOp}, nil
+	}
+	if err != nil {
+		// Prediction-safety: Helm may log-and-continue on this GET.
+		// Predict refuses to claim a resulting state.
+		return Result{}, fmt.Errorf("could not get information about the resource %s: %w",
+			resourceString(previous.obj), err)
+	}
+	if live.GetAnnotations()[kube.ResourcePolicyAnno] == kube.KeepPolicy {
+		return Result{
+			Identity:  previous.id,
+			Action:    ActionNoOp,
+			Live:      live,
+			Predicted: live.DeepCopy(),
+		}, nil
+	}
+	if delErr := cluster.Delete(ctx, previous.id); delErr != nil {
+		return Result{}, fmt.Errorf(
+			"failed to delete resource namespace=%s, name=%s, kind=%s: %w",
+			previous.id.Namespace, previous.id.Name, previous.id.Kind, delErr)
+	}
+	return Result{
+		Identity: previous.id,
+		Action:   ActionDelete,
+		Live:     live,
+	}, nil
+}

--- a/internal/predict/delete_test.go
+++ b/internal/predict/delete_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v4/pkg/kube"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"deployah.dev/deployah/internal/helm"
+	"deployah.dev/deployah/internal/predict"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func TestPredict_KeepPolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keep on live snapshots predicted", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("old", "prod", "web")
+		ann := live.GetAnnotations()
+		ann[kube.ResourcePolicyAnno] = kube.KeepPolicy
+		live.SetAnnotations(ann)
+		cluster := newFakeCluster()
+		cluster.store(live)
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("old", "prod", "prev"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "old")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionNoOp, got.Action)
+		require.NotNil(t, got.Live)
+		require.NotNil(t, got.Predicted)
+		assert.NotSame(t, got.Live, got.Predicted)
+		assert.Equal(t, got.Live.GetAnnotations()[kube.ResourcePolicyAnno], kube.KeepPolicy)
+		assert.Equal(t, got.Predicted.GetAnnotations()[kube.ResourcePolicyAnno], kube.KeepPolicy)
+		assert.Empty(t, cluster.deletes)
+	})
+
+	t.Run("keep only on previous does not skip", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("old", "prod", "web"))
+		previous := configMapYAMLWith("old", "prod", `  annotations:
+    helm.sh/resource-policy: keep
+`, "prev")
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    previous,
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "old")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionDelete, got.Action)
+		require.Len(t, cluster.deletes, 1)
+	})
+}
+
+func TestPredict_PruneGetErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+	cluster := newFakeCluster()
+	id := predict.Identity{Version: "v1", Kind: "ConfigMap", Namespace: "prod", Name: "old"}
+	cluster.getErr[objectKey(id)] = apierrors.NewForbidden(
+		schema.GroupResource{Resource: "configmaps"}, "old", errors.New("denied"))
+	_, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationUpgrade,
+		ReleaseName: "web",
+		Namespace:   "prod",
+		Previous:    configMapYAML("old", "prod", "prev"),
+		Desired:     configMapYAML("app", "prod", "next"),
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "could not get information about the resource")
+	assert.True(t, apierrors.IsForbidden(err), "Predict() prune GET = %v, want forbidden", err)
+	assert.Empty(t, cluster.deletes)
+}
+
+func TestPredict_DeleteDryRunFailure(t *testing.T) {
+	t.Parallel()
+	cluster := newFakeCluster()
+	cluster.store(ownedConfigMap("old", "prod", "web"))
+	cluster.deleteErr = apierrors.NewForbidden(
+		schema.GroupResource{Resource: "configmaps"}, "old", errors.New("denied"))
+	_, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationUpgrade,
+		ReleaseName: "web",
+		Namespace:   "prod",
+		Previous:    configMapYAML("old", "prod", "prev"),
+		Desired:     configMapYAML("app", "prod", "next"),
+	})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsForbidden(err), "Predict() delete = %v, want forbidden", err)
+}

--- a/internal/predict/delete_test.go
+++ b/internal/predict/delete_test.go
@@ -100,6 +100,68 @@ func TestPredict_PruneGetErrorFailsClosed(t *testing.T) {
 	assert.Empty(t, cluster.deletes)
 }
 
+func TestPredict_PruneDelete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retries conflict then succeeds", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("old", "prod", "web"))
+		cluster.deleteConflict = 1
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("old", "prod", "prev"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "old")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionDelete, got.Action)
+		assert.GreaterOrEqual(t, len(cluster.deletes), 2)
+	})
+
+	t.Run("delete not found after get is not an error", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("old", "prod", "web"))
+		cluster.deleteErr = apierrors.NewNotFound(
+			schema.GroupResource{Resource: "configmaps"}, "old")
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("old", "prod", "prev"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "old")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionDelete, got.Action)
+		assert.NotNil(t, got.Live)
+		assert.Nil(t, got.Predicted)
+		require.NotEmpty(t, cluster.deletes)
+	})
+
+	t.Run("non-not-found delete failure is an error", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("old", "prod", "web"))
+		cluster.deleteErr = apierrors.NewForbidden(
+			schema.GroupResource{Resource: "configmaps"}, "old", errors.New("denied"))
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("old", "prod", "prev"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err), "Predict() delete = %v, want forbidden", err)
+	})
+}
+
 func TestPredict_DeleteDryRunFailure(t *testing.T) {
 	t.Parallel()
 	cluster := newFakeCluster()

--- a/internal/predict/doc.go
+++ b/internal/predict/doc.go
@@ -1,0 +1,38 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package predict answers what Kubernetes resource state Deployah's Helm
+// server-side apply (SSA) path would produce, without mutating the cluster.
+//
+// [Predict] is a library. It is not the deployah plan command and is not
+// wired into plan or deploy.
+//
+// Deployah is SSA-only. There is no client-side apply predictor and no
+// apply-method switch. All production PATCH and DELETE calls use server
+// dry-run.
+//
+// Exact Helm-resource prediction requires that the cluster API surface
+// already exists at prediction time:
+//
+//   - the target release namespace already exists for namespaced resources
+//   - every Desired and Previous resource group/version/kind is currently
+//     discoverable and REST-mappable
+//
+// A missing namespace ([apierrors.IsNotFound]) or an unmapped kind
+// ([meta.IsNoMatchError]) is returned as the native typed error. Those
+// errors are not rewritten to [ActionNoOp]. They do not necessarily prove
+// that a real Deployah deploy would fail: install sets CreateNamespace, and
+// Deployah applies .deployah/crds/ before Helm. Namespace and CRD
+// prerequisite prediction are out of scope for this package.
+package predict

--- a/internal/predict/fake_test.go
+++ b/internal/predict/fake_test.go
@@ -1,0 +1,252 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"deployah.dev/deployah/internal/predict"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type recordedApply struct {
+	Name      string
+	Namespace string
+	Obj       *unstructured.Unstructured
+}
+
+type recordedJSONPatch struct {
+	ID    predict.Identity
+	Patch []byte
+}
+
+type recordedDelete struct {
+	ID predict.Identity
+}
+
+type fakeCluster struct {
+	objects           map[string]*unstructured.Unstructured
+	getErr            map[string]error
+	mappingErr        map[schema.GroupVersionKind]error
+	clusterScoped     map[schema.GroupVersionKind]bool
+	applyErr          error
+	applySeq          []error
+	applyCalls        int
+	jsonPatchErr      error
+	jsonPatchCalls    int
+	jsonPatchConflict int
+	deleteErr         error
+	gets              []predict.Identity
+	applies           []recordedApply
+	jsonPatches       []recordedJSONPatch
+	deletes           []recordedDelete
+}
+
+func newFakeCluster() *fakeCluster {
+	return &fakeCluster{
+		objects:       make(map[string]*unstructured.Unstructured),
+		getErr:        make(map[string]error),
+		mappingErr:    make(map[schema.GroupVersionKind]error),
+		clusterScoped: make(map[schema.GroupVersionKind]bool),
+	}
+}
+
+func objectKey(id predict.Identity) string {
+	gv := schema.GroupVersion{Group: id.Group, Version: id.Version}
+	return fmt.Sprintf("%s/%s/%s/%s", gv.String(), id.Kind, id.Namespace, id.Name)
+}
+
+func identityOf(obj *unstructured.Unstructured) predict.Identity {
+	gvk := obj.GroupVersionKind()
+	return predict.Identity{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}
+
+func (f *fakeCluster) store(obj *unstructured.Unstructured) {
+	f.objects[objectKey(identityOf(obj))] = obj.DeepCopy()
+}
+
+func (f *fakeCluster) Get(_ context.Context, id predict.Identity) (*unstructured.Unstructured, error) {
+	f.gets = append(f.gets, id)
+	if err, ok := f.getErr[objectKey(id)]; ok {
+		return nil, err
+	}
+	obj, ok := f.objects[objectKey(id)]
+	if !ok {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: strings.ToLower(id.Kind) + "s"}, id.Name)
+	}
+	return obj.DeepCopy(), nil
+}
+
+func (f *fakeCluster) Apply(_ context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	f.applyCalls++
+	f.applies = append(f.applies, recordedApply{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Obj:       obj.DeepCopy(),
+	})
+	if len(f.applySeq) > 0 {
+		err := f.applySeq[0]
+		f.applySeq = f.applySeq[1:]
+		if err != nil {
+			return nil, err
+		}
+	} else if f.applyErr != nil {
+		return nil, f.applyErr
+	}
+	return obj.DeepCopy(), nil
+}
+
+func (f *fakeCluster) JSONPatch(_ context.Context, id predict.Identity, patch []byte) error {
+	f.jsonPatchCalls++
+	f.jsonPatches = append(f.jsonPatches, recordedJSONPatch{ID: id, Patch: append([]byte(nil), patch...)})
+	if f.jsonPatchConflict > 0 {
+		f.jsonPatchConflict--
+		return apierrors.NewConflict(
+			schema.GroupResource{Resource: strings.ToLower(id.Kind) + "s"},
+			id.Name,
+			fmt.Errorf("the object has been modified"),
+		)
+	}
+	return f.jsonPatchErr
+}
+
+func (f *fakeCluster) Delete(_ context.Context, id predict.Identity) error {
+	f.deletes = append(f.deletes, recordedDelete{ID: id})
+	return f.deleteErr
+}
+
+func (f *fakeCluster) Mapping(gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	if err, ok := f.mappingErr[gvk]; ok {
+		return nil, err
+	}
+	scope := meta.RESTScopeNamespace
+	if f.clusterScoped[gvk] {
+		scope = meta.RESTScopeRoot
+	}
+	return &meta.RESTMapping{
+		Resource:         schema.GroupVersionResource{Group: gvk.Group, Version: gvk.Version, Resource: strings.ToLower(gvk.Kind) + "s"},
+		GroupVersionKind: gvk,
+		Scope:            scope,
+	}, nil
+}
+
+func configMapYAML(name, namespace, data string) string {
+	nsLine := ""
+	if namespace != "" {
+		nsLine = "\n  namespace: " + namespace
+	}
+	return fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s%s
+data:
+  key: %s
+`, name, nsLine, data)
+}
+
+func configMapYAMLWith(name, namespace, extraMeta, data string) string {
+	nsLine := ""
+	if namespace != "" {
+		nsLine = "\n  namespace: " + namespace
+	}
+	return fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s%s
+%s
+data:
+  key: %s
+`, name, nsLine, extraMeta, data)
+}
+
+func ownedConfigMap(name, namespace, release string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+			"labels": map[string]any{
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+			"annotations": map[string]any{
+				"meta.helm.sh/release-name":      release,
+				"meta.helm.sh/release-namespace": namespace,
+			},
+		},
+		"data": map[string]any{"key": "live"},
+	}}
+}
+
+func foreignConfigMap(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"data": map[string]any{"key": "foreign"},
+	}}
+}
+
+func findResult(results []predict.Result, name string) (predict.Result, bool) {
+	for _, r := range results {
+		if r.Identity.Name == name {
+			return r, true
+		}
+	}
+	return predict.Result{}, false
+}
+
+func resourceQuotaConflict() error {
+	return apierrors.NewConflict(
+		schema.GroupResource{Resource: "resourcequotas"},
+		"default",
+		fmt.Errorf("Operation cannot be fulfilled on resourcequotas \"default\": the object has been modified"),
+	)
+}
+
+func fieldManagerConflict() error {
+	return apierrors.NewConflict(
+		schema.GroupResource{Resource: "configmaps"},
+		"app",
+		fmt.Errorf("conflict with \"other-manager\""),
+	)
+}
+
+func deployahUpdateManagedFields() []metav1.ManagedFieldsEntry {
+	return []metav1.ManagedFieldsEntry{{
+		Manager:    "deployah",
+		Operation:  metav1.ManagedFieldsOperationUpdate,
+		APIVersion: "v1",
+		FieldsType: "FieldsV1",
+		FieldsV1:   metav1.NewFieldsV1(`{"f:data":{"f:key":{}}}`),
+	}}
+}

--- a/internal/predict/fake_test.go
+++ b/internal/predict/fake_test.go
@@ -56,6 +56,7 @@ type fakeCluster struct {
 	jsonPatchCalls    int
 	jsonPatchConflict int
 	deleteErr         error
+	deleteConflict    int
 	gets              []predict.Identity
 	applies           []recordedApply
 	jsonPatches       []recordedJSONPatch
@@ -138,6 +139,14 @@ func (f *fakeCluster) JSONPatch(_ context.Context, id predict.Identity, patch []
 
 func (f *fakeCluster) Delete(_ context.Context, id predict.Identity) error {
 	f.deletes = append(f.deletes, recordedDelete{ID: id})
+	if f.deleteConflict > 0 {
+		f.deleteConflict--
+		return apierrors.NewConflict(
+			schema.GroupResource{Resource: strings.ToLower(id.Kind) + "s"},
+			id.Name,
+			fmt.Errorf("the object has been modified"),
+		)
+	}
 	return f.deleteErr
 }
 
@@ -201,6 +210,34 @@ func ownedConfigMap(name, namespace, release string) *unstructured.Unstructured 
 			},
 		},
 		"data": map[string]any{"key": "live"},
+	}}
+}
+
+func clusterWidgetGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "ClusterWidget"}
+}
+
+func clusterWidgetYAML(name, namespace string) string {
+	nsLine := ""
+	if namespace != "" {
+		nsLine = "\n  namespace: " + namespace
+	}
+	return fmt.Sprintf(`apiVersion: example.com/v1
+kind: ClusterWidget
+metadata:
+  name: %s%s
+`, name, nsLine)
+}
+
+func clusterWidget(name, namespace string) *unstructured.Unstructured {
+	meta := map[string]any{"name": name}
+	if namespace != "" {
+		meta["namespace"] = namespace
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "ClusterWidget",
+		"metadata":   meta,
 	}}
 }
 

--- a/internal/predict/identity.go
+++ b/internal/predict/identity.go
@@ -109,8 +109,12 @@ func loadResources(cluster Cluster, manifest, defaultNamespace string) ([]resour
 			return nil, fmt.Errorf("resolve resource mapping for %s %s: %w",
 				obj.GroupVersionKind(), obj.GetName(), mapErr)
 		}
-		if mapping.Scope.Name() == meta.RESTScopeNameNamespace && obj.GetNamespace() == "" {
-			obj.SetNamespace(defaultNamespace)
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+			if obj.GetNamespace() == "" {
+				obj.SetNamespace(defaultNamespace)
+			}
+		} else {
+			obj.SetNamespace("")
 		}
 		out = append(out, resourceObj{id: identityOf(obj), obj: obj})
 	}

--- a/internal/predict/identity.go
+++ b/internal/predict/identity.go
@@ -1,0 +1,132 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+type resourceObj struct {
+	id  Identity
+	obj *unstructured.Unstructured
+}
+
+// GroupVersionKind returns the API group, version, and kind of id.
+func (id Identity) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: id.Group, Version: id.Version, Kind: id.Kind}
+}
+
+func identityOf(obj *unstructured.Unstructured) Identity {
+	gvk := obj.GroupVersionKind()
+	return Identity{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}
+
+// objectKey matches Helm pkg/action/upgrade.go: groupVersion/kind/ns/name.
+func objectKey(id Identity) string {
+	gv := schema.GroupVersion{Group: id.Group, Version: id.Version}
+	return fmt.Sprintf("%s/%s/%s/%s", gv.String(), id.Kind, id.Namespace, id.Name)
+}
+
+// sameResource matches Helm isMatchingInfo: name, namespace, GroupKind.
+func sameResource(a, b Identity) bool {
+	return a.Name == b.Name && a.Namespace == b.Namespace && a.Group == b.Group && a.Kind == b.Kind
+}
+
+func flattenManifest(manifest string) ([]*unstructured.Unstructured, error) {
+	if strings.TrimSpace(manifest) == "" {
+		return nil, nil
+	}
+	infos, err := resource.NewLocalBuilder().
+		ContinueOnError().
+		Flatten().
+		Unstructured().
+		Stream(bytes.NewBufferString(manifest), "manifest").
+		Do().Infos()
+	if err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	out := make([]*unstructured.Unstructured, 0, len(infos))
+	for _, info := range infos {
+		u, convErr := asUnstructured(info.Object)
+		if convErr != nil {
+			return nil, convErr
+		}
+		out = append(out, u)
+	}
+	return out, nil
+}
+
+func asUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return u.DeepCopy(), nil
+	}
+	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("convert object to unstructured: %w", err)
+	}
+	return &unstructured.Unstructured{Object: m}, nil
+}
+
+func loadResources(cluster Cluster, manifest, defaultNamespace string) ([]resourceObj, error) {
+	objs, err := flattenManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]resourceObj, 0, len(objs))
+	for _, obj := range objs {
+		if _, genErr := generateNameState(obj); genErr != nil {
+			return nil, genErr
+		}
+		mapping, mapErr := cluster.Mapping(obj.GroupVersionKind())
+		if mapErr != nil {
+			return nil, fmt.Errorf("resolve resource mapping for %s %s: %w",
+				obj.GroupVersionKind(), obj.GetName(), mapErr)
+		}
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace && obj.GetNamespace() == "" {
+			obj.SetNamespace(defaultNamespace)
+		}
+		out = append(out, resourceObj{id: identityOf(obj), obj: obj})
+	}
+	return out, nil
+}
+
+// generateNameState mirrors Helm validateNameAndGenerateName. A generateName
+// without a name skips ownership. Name and generateName together is an error.
+func generateNameState(obj *unstructured.Unstructured) (bool, error) {
+	name := obj.GetName()
+	generateName := obj.GetGenerateName()
+	if name == "" && generateName != "" {
+		return true, nil
+	}
+	if name != "" && generateName != "" {
+		return false, errors.New("metadata.name and metadata.generateName cannot both be set")
+	}
+	return false, nil
+}

--- a/internal/predict/identity_test.go
+++ b/internal/predict/identity_test.go
@@ -1,0 +1,356 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"deployah.dev/deployah/internal/helm"
+	"deployah.dev/deployah/internal/predict"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+)
+
+func TestPredict_ObjectKeyIncludesVersion(t *testing.T) {
+	t.Parallel()
+	// Same name/namespace/kind, different API version is new-to-release.
+	cluster := newFakeCluster()
+	live := foreignConfigMap("app", "prod")
+	live.SetAPIVersion("example.com/v2")
+	cluster.store(live)
+	previous := `apiVersion: example.com/v1
+kind: ConfigMap
+metadata:
+  name: app
+  namespace: prod
+data:
+  key: prev
+`
+	desired := `apiVersion: example.com/v2
+kind: ConfigMap
+metadata:
+  name: app
+  namespace: prod
+data:
+  key: next
+`
+	_, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationUpgrade,
+		ReleaseName: "web",
+		Namespace:   "prod",
+		Previous:    previous,
+		Desired:     desired,
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cannot be imported")
+}
+
+func TestPredict_GroupKindPruneIgnoresVersion(t *testing.T) {
+	t.Parallel()
+	cluster := newFakeCluster()
+	previous := `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: app
+  namespace: prod
+`
+	desired := `apiVersion: example.com/v2
+kind: Widget
+metadata:
+  name: app
+  namespace: prod
+`
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationUpgrade,
+		ReleaseName: "web",
+		Namespace:   "prod",
+		Previous:    previous,
+		Desired:     desired,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, predict.ActionCreate, results[0].Action)
+	assert.Equal(t, "v2", results[0].Identity.Version)
+	assert.Empty(t, cluster.deletes)
+}
+
+func TestPredict_GenerateName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skips ownership get", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		desired := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  generateName: app-
+  namespace: prod
+data:
+  key: next
+`
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, predict.ActionCreate, results[0].Action)
+		assert.Empty(t, cluster.gets)
+		require.Len(t, cluster.applies, 1)
+		assert.Equal(t, "app-", cluster.applies[0].Obj.GetGenerateName())
+	})
+
+	t.Run("name and generateName error", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		desired := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app
+  generateName: app-
+  namespace: prod
+data:
+  key: next
+`
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "metadata.name and metadata.generateName cannot both be set")
+	})
+}
+
+func TestPredict_Flatten(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multi-document yaml", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		desired := configMapYAML("one", "prod", "a") + "---\n" + configMapYAML("two", "prod", "b")
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+		_, ok := findResult(results, "one")
+		assert.True(t, ok)
+		_, ok = findResult(results, "two")
+		assert.True(t, ok)
+	})
+
+	t.Run("list expands to items", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		desired := `apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: one
+    namespace: prod
+  data:
+    key: a
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: two
+    namespace: prod
+  data:
+    key: b
+`
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+		for _, r := range results {
+			assert.NotEqual(t, "List", r.Identity.Kind)
+			assert.Equal(t, predict.ActionCreate, r.Action)
+		}
+	})
+
+	t.Run("list items own independently", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(foreignConfigMap("two", "prod"))
+		desired := `apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: one
+    namespace: prod
+  data:
+    key: a
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: two
+    namespace: prod
+  data:
+    key: b
+`
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot be imported")
+	})
+
+	t.Run("list items prune independently", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		live := ownedConfigMap("two", "prod", "web")
+		cluster.store(live)
+		previous := `apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: one
+    namespace: prod
+  data:
+    key: a
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: two
+    namespace: prod
+  data:
+    key: b
+`
+		desired := configMapYAML("one", "prod", "a")
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    previous,
+			Desired:     desired,
+		})
+		require.NoError(t, err)
+		pruned, ok := findResult(results, "two")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionDelete, pruned.Action)
+		require.Len(t, cluster.deletes, 1)
+		assert.Equal(t, "two", cluster.deletes[0].ID.Name)
+	})
+
+	t.Run("mapping error on flattened item", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"}
+		cluster.mappingErr[gvk] = &apimeta.NoKindMatchError{GroupKind: gvk.GroupKind()}
+		desired := `apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: one
+    namespace: prod
+- apiVersion: example.com/v1
+  kind: Widget
+  metadata:
+    name: two
+    namespace: prod
+`
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.True(t, apimeta.IsNoMatchError(err), "Predict() mapping error = %v, want IsNoMatchError", err)
+	})
+
+	t.Run("defaults empty namespace", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		desired := configMapYAML("app", "", "next")
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, "prod", got.Identity.Namespace)
+		require.Len(t, cluster.applies, 1)
+		assert.Equal(t, "prod", cluster.applies[0].Namespace)
+	})
+}
+
+func TestPredict_PrerequisiteErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing namespace not found", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.applyErr = apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, "missing")
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "missing",
+			Desired:     configMapYAML("app", "missing", "next"),
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err), "Predict() = %v, want IsNotFound", err)
+	})
+
+	t.Run("no match mapping", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"}
+		cluster.mappingErr[gvk] = &apimeta.NoKindMatchError{GroupKind: gvk.GroupKind()}
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired: `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: app
+  namespace: prod
+`,
+		})
+		require.Error(t, err)
+		assert.True(t, apimeta.IsNoMatchError(err), "Predict() = %v, want IsNoMatchError", err)
+	})
+}

--- a/internal/predict/identity_test.go
+++ b/internal/predict/identity_test.go
@@ -317,6 +317,71 @@ items:
 	})
 }
 
+func TestPredict_ClusterScopedClearsNamespace(t *testing.T) {
+	t.Parallel()
+	gvk := clusterWidgetGVK()
+
+	t.Run("desired clears supplied namespace", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.clusterScoped[gvk] = true
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     clusterWidgetYAML("app", "prod"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Empty(t, got.Identity.Namespace)
+		require.Len(t, cluster.applies, 1)
+		assert.Empty(t, cluster.applies[0].Namespace)
+		assert.Empty(t, cluster.applies[0].Obj.GetNamespace())
+	})
+
+	t.Run("previous matching uses cleared namespace", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.clusterScoped[gvk] = true
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    clusterWidgetYAML("app", "prod"),
+			Desired:     clusterWidgetYAML("app", "staging"),
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, predict.ActionCreate, results[0].Action)
+		assert.Empty(t, results[0].Identity.Namespace)
+		assert.Empty(t, cluster.deletes)
+		require.Len(t, cluster.applies, 1)
+		assert.Empty(t, cluster.applies[0].Namespace)
+	})
+
+	t.Run("previous prune uses cleared namespace", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.clusterScoped[gvk] = true
+		cluster.store(clusterWidget("old", ""))
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    clusterWidgetYAML("old", "prod"),
+			Desired:     clusterWidgetYAML("app", "prod"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "old")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionDelete, got.Action)
+		assert.Empty(t, got.Identity.Namespace)
+		require.Len(t, cluster.deletes, 1)
+		assert.Empty(t, cluster.deletes[0].ID.Namespace)
+	})
+}
+
 func TestPredict_PrerequisiteErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/predict/normalize.go
+++ b/internal/predict/normalize.go
@@ -1,0 +1,38 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func equalBookkeeping(live, predicted *unstructured.Unstructured) bool {
+	if live == nil || predicted == nil {
+		return false
+	}
+	return equality.Semantic.DeepEqual(bookkeepingCopy(live).Object, bookkeepingCopy(predicted).Object)
+}
+
+func bookkeepingCopy(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	cp := obj.DeepCopy()
+	unstructured.RemoveNestedField(cp.Object, "status")
+	unstructured.RemoveNestedField(cp.Object, "metadata", "resourceVersion")
+	unstructured.RemoveNestedField(cp.Object, "metadata", "uid")
+	unstructured.RemoveNestedField(cp.Object, "metadata", "generation")
+	unstructured.RemoveNestedField(cp.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(cp.Object, "metadata", "managedFields")
+	return cp
+}

--- a/internal/predict/ownership.go
+++ b/internal/predict/ownership.go
@@ -1,0 +1,84 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	appManagedByLabel              = "app.kubernetes.io/managed-by"
+	appManagedByHelm               = "Helm"
+	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
+	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
+)
+
+func stampMetadata(obj *unstructured.Unstructured, releaseName, releaseNamespace string) {
+	obj.SetLabels(mergeStrStrMaps(obj.GetLabels(), map[string]string{
+		appManagedByLabel: appManagedByHelm,
+	}))
+	obj.SetAnnotations(mergeStrStrMaps(obj.GetAnnotations(), map[string]string{
+		helmReleaseNameAnnotation:      releaseName,
+		helmReleaseNamespaceAnnotation: releaseNamespace,
+	}))
+}
+
+func mergeStrStrMaps(current, desired map[string]string) map[string]string {
+	result := make(map[string]string, len(current)+len(desired))
+	maps.Copy(result, current)
+	maps.Copy(result, desired)
+	return result
+}
+
+func checkOwnership(obj *unstructured.Unstructured, releaseName, releaseNamespace string) error {
+	var errs []error
+	if err := requireValue(obj.GetLabels(), appManagedByLabel, appManagedByHelm); err != nil {
+		errs = append(errs, fmt.Errorf("label validation error: %w", err))
+	}
+	if err := requireValue(obj.GetAnnotations(), helmReleaseNameAnnotation, releaseName); err != nil {
+		errs = append(errs, fmt.Errorf("annotation validation error: %w", err))
+	}
+	if err := requireValue(obj.GetAnnotations(), helmReleaseNamespaceAnnotation, releaseNamespace); err != nil {
+		errs = append(errs, fmt.Errorf("annotation validation error: %w", err))
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid ownership metadata; %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+func requireValue(meta map[string]string, k, v string) error {
+	actual, ok := meta[k]
+	if !ok {
+		return fmt.Errorf("missing key %q: must be set to %q", k, v)
+	}
+	if actual != v {
+		return fmt.Errorf("key %q must equal %q: current value is %q", k, v, actual)
+	}
+	return nil
+}
+
+func resourceString(obj *unstructured.Unstructured) string {
+	return fmt.Sprintf("%s %q in namespace %q", obj.GetKind(), obj.GetName(), obj.GetNamespace())
+}
+
+func ownershipConflict(obj *unstructured.Unstructured, err error) error {
+	return fmt.Errorf("%s exists and cannot be imported into the current release: %w",
+		resourceString(obj), err)
+}

--- a/internal/predict/ownership_test.go
+++ b/internal/predict/ownership_test.go
@@ -1,0 +1,192 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"deployah.dev/deployah/internal/helm"
+	"deployah.dev/deployah/internal/predict"
+)
+
+func TestPredict_Ownership(t *testing.T) {
+	t.Parallel()
+
+	desired := configMapYAML("app", "prod", "next")
+
+	t.Run("correctly owned install adoption", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("app", "prod", "web"))
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionUpdate, got.Action)
+		assert.Empty(t, got.Limitation)
+	})
+
+	t.Run("missing managed-by", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		require.NoError(t, unstructured.SetNestedField(live.Object, map[string]any{}, "metadata", "labels"))
+		cluster := newFakeCluster()
+		cluster.store(live)
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot be imported")
+		assert.ErrorContains(t, err, "app.kubernetes.io/managed-by")
+	})
+
+	t.Run("wrong managed-by", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		live.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "Helmfile"})
+		cluster := newFakeCluster()
+		cluster.store(live)
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot be imported")
+		assert.ErrorContains(t, err, "app.kubernetes.io/managed-by")
+	})
+
+	t.Run("wrong release name", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("app", "prod", "other"))
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "meta.helm.sh/release-name")
+	})
+
+	t.Run("wrong release namespace", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		ann := live.GetAnnotations()
+		ann["meta.helm.sh/release-namespace"] = "other"
+		live.SetAnnotations(ann)
+		cluster := newFakeCluster()
+		cluster.store(live)
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "meta.helm.sh/release-namespace")
+	})
+
+	t.Run("foreign existing resource on install", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(foreignConfigMap("app", "prod"))
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot be imported")
+	})
+
+	t.Run("foreign new resource on upgrade", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(foreignConfigMap("app", "prod"))
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("old", "prod", "prev"),
+			Desired:     desired,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot be imported")
+	})
+
+	t.Run("already in previous skips ownership", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(foreignConfigMap("app", "prod"))
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("app", "prod", "prev"),
+			Desired:     desired,
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionUpdate, got.Action)
+	})
+}
+
+func TestPredict_MetadataStamp(t *testing.T) {
+	t.Parallel()
+	cluster := newFakeCluster()
+	desired := configMapYAMLWith("app", "prod", `  labels:
+    app.kubernetes.io/managed-by: Other
+    app: web
+  annotations:
+    meta.helm.sh/release-name: stale
+    owner: team
+`, "next")
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   "prod",
+		Desired:     desired,
+	})
+	require.NoError(t, err)
+	got, ok := findResult(results, "app")
+	require.True(t, ok)
+	require.NotNil(t, got.Predicted)
+	assert.Equal(t, "Helm", got.Predicted.GetLabels()["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "web", got.Predicted.GetLabels()["app"])
+	assert.Equal(t, "web", got.Predicted.GetAnnotations()["meta.helm.sh/release-name"])
+	assert.Equal(t, "prod", got.Predicted.GetAnnotations()["meta.helm.sh/release-namespace"])
+	assert.Equal(t, "team", got.Predicted.GetAnnotations()["owner"])
+	require.Len(t, cluster.applies, 1)
+	applied := cluster.applies[0].Obj
+	assert.Equal(t, "Helm", applied.GetLabels()["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "web", applied.GetAnnotations()["meta.helm.sh/release-name"])
+}

--- a/internal/predict/predict.go
+++ b/internal/predict/predict.go
@@ -1,0 +1,217 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"deployah.dev/deployah/internal/helm"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// Predict reports the Kubernetes resource state Deployah's Helm
+// server-side apply path would produce for in. It does not mutate the
+// cluster. Production [Cluster] implementations send server dry-run on
+// every write.
+//
+// Exact prediction requires that the release namespace already exists
+// for namespaced resources and that every resource group/version/kind
+// is REST-mappable. Missing-namespace [apierrors.IsNotFound] and
+// unmapped-kind [meta.IsNoMatchError] are returned as native typed
+// errors, not rewritten to [ActionNoOp]. Those errors do not
+// necessarily prove a real Deployah deploy would fail.
+func Predict(ctx context.Context, cluster Cluster, in Input) ([]Result, error) {
+	if err := validateInput(in); err != nil {
+		return nil, err
+	}
+	if cluster == nil {
+		return nil, errors.New("cluster is required")
+	}
+
+	previous, err := loadResources(cluster, in.Previous, in.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	desired, err := loadResources(cluster, in.Desired, in.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	for i := range desired {
+		stampMetadata(desired[i].obj, in.ReleaseName, in.Namespace)
+		desired[i].id = identityOf(desired[i].obj)
+	}
+
+	prevByObjectKey := make(map[string]resourceObj, len(previous))
+	for _, p := range previous {
+		prevByObjectKey[objectKey(p.id)] = p
+	}
+
+	results := make([]Result, 0, len(desired)+len(previous))
+	for _, d := range desired {
+		r, predErr := predictDesired(ctx, cluster, in, d, prevByObjectKey)
+		if predErr != nil {
+			return nil, predErr
+		}
+		results = append(results, r)
+	}
+	for _, p := range previous {
+		if desiredHasResource(desired, p.id) {
+			continue
+		}
+		r, pruneErr := predictPrune(ctx, cluster, p)
+		if pruneErr != nil {
+			return nil, pruneErr
+		}
+		results = append(results, r)
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return results, nil
+}
+
+func validateInput(in Input) error {
+	switch in.Operation {
+	case helm.OperationInstall, helm.OperationUpgrade:
+	default:
+		return fmt.Errorf("invalid helm operation %d", in.Operation)
+	}
+	if in.ReleaseName == "" {
+		return errors.New("release name is required")
+	}
+	if in.Namespace == "" {
+		return errors.New("release namespace is required")
+	}
+	return nil
+}
+
+func desiredHasResource(desired []resourceObj, id Identity) bool {
+	for _, d := range desired {
+		if sameResource(d.id, id) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNewToRelease(op helm.Operation, id Identity, previous map[string]resourceObj) bool {
+	if op == helm.OperationInstall {
+		return true
+	}
+	_, ok := previous[objectKey(id)]
+	return !ok
+}
+
+func predictDesired(
+	ctx context.Context,
+	cluster Cluster,
+	in Input,
+	desired resourceObj,
+	previous map[string]resourceObj,
+) (Result, error) {
+	generateName, err := generateNameState(desired.obj)
+	if err != nil {
+		return Result{}, err
+	}
+	if generateName {
+		predicted, applyErr := applyCreate(ctx, cluster, desired.obj)
+		if applyErr != nil {
+			return Result{}, applyErr
+		}
+		return Result{
+			Identity:  desired.id,
+			Action:    ActionCreate,
+			Predicted: predicted,
+		}, nil
+	}
+
+	needOwnership := isNewToRelease(in.Operation, desired.id, previous)
+	live, err := cluster.Get(ctx, desired.id)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return Result{}, fmt.Errorf("could not get information about the resource %s: %w",
+			resourceString(desired.obj), err)
+	}
+	if apierrors.IsNotFound(err) {
+		live = nil
+	}
+
+	if needOwnership && live != nil {
+		if ownErr := checkOwnership(live, in.ReleaseName, in.Namespace); ownErr != nil {
+			return Result{}, ownershipConflict(live, ownErr)
+		}
+	}
+
+	if live == nil {
+		predicted, applyErr := applyCreate(ctx, cluster, desired.obj)
+		if applyErr != nil {
+			return Result{}, applyErr
+		}
+		return Result{
+			Identity:  desired.id,
+			Action:    ActionCreate,
+			Predicted: predicted,
+		}, nil
+	}
+
+	limitation := ""
+	if in.Operation == helm.OperationInstall && needOwnership {
+		var migErr error
+		limitation, migErr = migrateManagedFields(ctx, cluster, desired.id, &live)
+		if migErr != nil {
+			return Result{}, migErr
+		}
+	}
+
+	if limitation != "" {
+		predicted, applyErr := applyUpdate(ctx, cluster, desired.obj)
+		if applyErr != nil {
+			return Result{
+				Identity:   desired.id,
+				Action:     ActionUpdate,
+				Live:       live,
+				Limitation: limitation,
+			}, nil
+		}
+		return Result{
+			Identity:   desired.id,
+			Action:     ActionUpdate,
+			Live:       live,
+			Predicted:  predicted,
+			Limitation: limitation,
+		}, nil
+	}
+
+	predicted, applyErr := applyUpdate(ctx, cluster, desired.obj)
+	if applyErr != nil {
+		return Result{}, applyErr
+	}
+	if equalBookkeeping(live, predicted) {
+		return Result{
+			Identity:  desired.id,
+			Action:    ActionNoOp,
+			Live:      live,
+			Predicted: predicted,
+		}, nil
+	}
+	return Result{
+		Identity:  desired.id,
+		Action:    ActionUpdate,
+		Live:      live,
+		Predicted: predicted,
+	}, nil
+}

--- a/internal/predict/predict.go
+++ b/internal/predict/predict.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"deployah.dev/deployah/internal/helm"
 
@@ -96,6 +97,9 @@ func validateInput(in Input) error {
 	}
 	if in.Namespace == "" {
 		return errors.New("release namespace is required")
+	}
+	if in.Operation == helm.OperationInstall && strings.TrimSpace(in.Previous) != "" {
+		return errors.New("previous manifest is not allowed on install")
 	}
 	return nil
 }

--- a/internal/predict/predict_test.go
+++ b/internal/predict/predict_test.go
@@ -484,3 +484,21 @@ func TestPredict_RejectsInvalidInput(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "release namespace is required")
 }
+
+func TestPredict_RejectsInstallPrevious(t *testing.T) {
+	t.Parallel()
+	cluster := newFakeCluster()
+	_, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   "prod",
+		Previous:    configMapYAML("old", "prod", "prev"),
+		Desired:     configMapYAML("app", "prod", "next"),
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "previous manifest is not allowed on install")
+	assert.Empty(t, cluster.gets)
+	assert.Empty(t, cluster.applies)
+	assert.Empty(t, cluster.jsonPatches)
+	assert.Empty(t, cluster.deletes)
+}

--- a/internal/predict/predict_test.go
+++ b/internal/predict/predict_test.go
@@ -1,0 +1,486 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"deployah.dev/deployah/internal/helm"
+	"deployah.dev/deployah/internal/predict"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPredict_Actions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing live is create", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionCreate, got.Action)
+		assert.Nil(t, got.Live)
+		require.NotNil(t, got.Predicted)
+	})
+
+	t.Run("changed live is update", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("app", "prod", "web"))
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionUpdate, got.Action)
+	})
+
+	t.Run("identical normalized state is noop", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		require.NoError(t, unstructured.SetNestedField(live.Object, "next", "data", "key"))
+		live.SetResourceVersion("9")
+		live.SetUID("uid-1")
+		live.SetManagedFields(deployahUpdateManagedFields())
+		require.NoError(t, unstructured.SetNestedField(live.Object, map[string]any{"ready": true}, "status"))
+		cluster := newFakeCluster()
+		cluster.store(live)
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("app", "prod", "next"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionNoOp, got.Action)
+		require.NotNil(t, got.Live)
+		require.NotNil(t, got.Predicted)
+	})
+
+	t.Run("removed previous is delete", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("old", "prod", "web"))
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("old", "prod", "prev"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "old")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionDelete, got.Action)
+		assert.NotNil(t, got.Live)
+		assert.Nil(t, got.Predicted)
+	})
+
+	t.Run("removed previous already gone is noop", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("old", "prod", "prev"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "old")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionNoOp, got.Action)
+		assert.Nil(t, got.Live)
+		assert.Nil(t, got.Predicted)
+		assert.Empty(t, cluster.deletes)
+	})
+}
+
+func TestPredict_Normalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("status only is noop", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		require.NoError(t, unstructured.SetNestedField(live.Object, "next", "data", "key"))
+		require.NoError(t, unstructured.SetNestedField(live.Object, map[string]any{"phase": "Ready"}, "status"))
+		cluster := newFakeCluster()
+		cluster.store(live)
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("app", "prod", "next"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionNoOp, got.Action)
+	})
+
+	t.Run("resourceVersion uid managedFields only is noop", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		require.NoError(t, unstructured.SetNestedField(live.Object, "next", "data", "key"))
+		live.SetResourceVersion("42")
+		live.SetUID("abc")
+		live.SetGeneration(7)
+		live.SetCreationTimestamp(metav1.Now())
+		live.SetManagedFields(deployahUpdateManagedFields())
+		cluster := newFakeCluster()
+		cluster.store(live)
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("app", "prod", "next"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionNoOp, got.Action)
+	})
+
+	t.Run("external annotation stays update", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		require.NoError(t, unstructured.SetNestedField(live.Object, "next", "data", "key"))
+		ann := live.GetAnnotations()
+		ann["deployah.dev/external"] = "keep-me"
+		live.SetAnnotations(ann)
+		cluster := newFakeCluster()
+		cluster.store(live)
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("app", "prod", "next"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionUpdate, got.Action)
+	})
+
+	t.Run("does not mutate live or predicted", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		require.NoError(t, unstructured.SetNestedField(live.Object, "next", "data", "key"))
+		live.SetResourceVersion("9")
+		require.NoError(t, unstructured.SetNestedField(live.Object, map[string]any{"ready": true}, "status"))
+		cluster := newFakeCluster()
+		cluster.store(live)
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("app", "prod", "next"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, "9", got.Live.GetResourceVersion())
+		_, found, nestErr := unstructured.NestedFieldNoCopy(got.Live.Object, "status")
+		require.NoError(t, nestErr)
+		assert.True(t, found)
+		_, found, nestErr = unstructured.NestedFieldNoCopy(got.Predicted.Object, "status")
+		require.NoError(t, nestErr)
+		assert.False(t, found)
+	})
+}
+
+func TestPredict_CreateOnlyResourceQuotaRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create retries quota conflict", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.applySeq = []error{resourceQuotaConflict(), nil}
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionCreate, got.Action)
+		assert.GreaterOrEqual(t, cluster.applyCalls, 2)
+	})
+
+	t.Run("update does not retry quota conflict", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(ownedConfigMap("app", "prod", "web"))
+		cluster.applyErr = resourceQuotaConflict()
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err), "Predict() = %v, want conflict", err)
+		assert.Equal(t, 1, cluster.applyCalls)
+	})
+
+	t.Run("field manager conflict is an error", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.applyErr = fieldManagerConflict()
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err), "Predict() = %v, want conflict", err)
+	})
+}
+
+func TestPredict_ManagedFieldsMigration(t *testing.T) {
+	t.Parallel()
+
+	seedAdopted := func() *unstructured.Unstructured {
+		live := ownedConfigMap("app", "prod", "web")
+		live.SetResourceVersion("7")
+		live.SetManagedFields(deployahUpdateManagedFields())
+		return live
+	}
+
+	t.Run("empty patch is exact ssa", func(t *testing.T) {
+		t.Parallel()
+		live := ownedConfigMap("app", "prod", "web")
+		live.SetManagedFields([]metav1.ManagedFieldsEntry{{
+			Manager:    "deployah",
+			Operation:  metav1.ManagedFieldsOperationApply,
+			APIVersion: "v1",
+			FieldsType: "FieldsV1",
+			FieldsV1:   metav1.NewFieldsV1(`{"f:data":{"f:key":{}}}`),
+		}})
+		cluster := newFakeCluster()
+		cluster.store(live)
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Empty(t, got.Limitation)
+		assert.Empty(t, cluster.jsonPatches)
+		assert.Equal(t, predict.ActionUpdate, got.Action)
+	})
+
+	t.Run("migration dry-run failure is an error", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(seedAdopted())
+		cluster.jsonPatchErr = apierrors.NewForbidden(
+			schema.GroupResource{Resource: "configmaps"}, "app", errors.New("denied"))
+		_, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to patch object to upgrade CSA field manager")
+		assert.True(t, apierrors.IsForbidden(err), "Predict() = %v, want forbidden", err)
+	})
+
+	t.Run("migration success and ssa success keeps limitation", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(seedAdopted())
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.LimitationManagedFieldsMigration, got.Limitation)
+		assert.Equal(t, predict.ActionUpdate, got.Action)
+		require.NotNil(t, got.Predicted)
+		require.NotEmpty(t, cluster.jsonPatches)
+		assert.NotEmpty(t, cluster.jsonPatches[0].Patch)
+	})
+
+	t.Run("migration success and ssa failure is not a deploy error", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(seedAdopted())
+		cluster.applyErr = fieldManagerConflict()
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.LimitationManagedFieldsMigration, got.Limitation)
+		assert.Equal(t, predict.ActionUpdate, got.Action)
+		assert.Nil(t, got.Predicted)
+		assert.NotNil(t, got.Live)
+	})
+
+	t.Run("migration success skips noop", func(t *testing.T) {
+		t.Parallel()
+		live := seedAdopted()
+		require.NoError(t, unstructured.SetNestedField(live.Object, "next", "data", "key"))
+		cluster := newFakeCluster()
+		cluster.store(live)
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.ActionUpdate, got.Action)
+		assert.Equal(t, predict.LimitationManagedFieldsMigration, got.Limitation)
+	})
+
+	t.Run("retry on conflict re-gets", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(seedAdopted())
+		cluster.jsonPatchConflict = 1
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Equal(t, predict.LimitationManagedFieldsMigration, got.Limitation)
+		assert.GreaterOrEqual(t, cluster.jsonPatchCalls, 2)
+	})
+
+	t.Run("upgrade does not migrate", func(t *testing.T) {
+		t.Parallel()
+		cluster := newFakeCluster()
+		cluster.store(seedAdopted())
+		results, err := predict.Predict(t.Context(), cluster, predict.Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: "web",
+			Namespace:   "prod",
+			Previous:    configMapYAML("other", "prod", "prev"),
+			Desired:     configMapYAML("app", "prod", "next"),
+		})
+		require.NoError(t, err)
+		got, ok := findResult(results, "app")
+		require.True(t, ok)
+		assert.Empty(t, got.Limitation)
+		assert.Empty(t, cluster.jsonPatches)
+	})
+}
+
+func TestPredict_DesiredGetError(t *testing.T) {
+	t.Parallel()
+	cluster := newFakeCluster()
+	id := predict.Identity{Version: "v1", Kind: "ConfigMap", Namespace: "prod", Name: "app"}
+	cluster.getErr[objectKey(id)] = apierrors.NewForbidden(
+		schema.GroupResource{Resource: "configmaps"}, "app", errors.New("denied"))
+	_, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   "prod",
+		Desired:     configMapYAML("app", "prod", "next"),
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "could not get information about the resource")
+	assert.True(t, apierrors.IsForbidden(err), "Predict() desired GET = %v, want forbidden", err)
+	assert.Empty(t, cluster.applies)
+}
+
+func TestPredict_EmptyManifests(t *testing.T) {
+	t.Parallel()
+	cluster := newFakeCluster()
+	results, err := predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Namespace:   "prod",
+	})
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+func TestPredict_RejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+	cluster := newFakeCluster()
+	_, err := predict.Predict(t.Context(), cluster, predict.Input{
+		ReleaseName: "web",
+		Namespace:   "prod",
+		Desired:     configMapYAML("app", "prod", "next"),
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid helm operation")
+
+	_, err = predict.Predict(t.Context(), cluster, predict.Input{
+		Operation: helm.OperationInstall,
+		Namespace: "prod",
+		Desired:   configMapYAML("app", "prod", "next"),
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "release name is required")
+
+	_, err = predict.Predict(t.Context(), cluster, predict.Input{
+		Operation:   helm.OperationInstall,
+		ReleaseName: "web",
+		Desired:     configMapYAML("app", "prod", "next"),
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "release namespace is required")
+}

--- a/internal/predict/ssa.go
+++ b/internal/predict/ssa.go
@@ -1,0 +1,94 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"helm.sh/helm/v4/pkg/kube"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/csaupgrade"
+	"k8s.io/client-go/util/retry"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func applyCreate(ctx context.Context, cluster Cluster, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var predicted *unstructured.Unstructured
+	err := retry.OnError(retry.DefaultRetry, isResourceQuotaConflict, func() error {
+		var applyErr error
+		predicted, applyErr = cluster.Apply(ctx, obj)
+		return applyErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return predicted, nil
+}
+
+func applyUpdate(ctx context.Context, cluster Cluster, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	return cluster.Apply(ctx, obj)
+}
+
+// isResourceQuotaConflict matches Helm pkg/kube isResourceQuotaConflict.
+// The string match is Helm's predicate, not a local invention.
+func isResourceQuotaConflict(err error) bool {
+	if err == nil || !apierrors.IsConflict(err) {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Operation cannot be fulfilled on resourcequotas") &&
+		strings.Contains(msg, "the object has been modified")
+}
+
+// migrateManagedFields dry-runs Helm's install-adoption CSA-to-SSA
+// managed-fields patch. An empty computed patch is exact SSA. A
+// non-empty patch that the API accepts sets
+// [LimitationManagedFieldsMigration]. A failed dry-run is an error.
+func migrateManagedFields(ctx context.Context, cluster Cluster, id Identity, live **unstructured.Unstructured) (string, error) {
+	limitation := ""
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh, getErr := cluster.Get(ctx, id)
+		if getErr != nil {
+			return fmt.Errorf("failed to get object %s/%s %s: %w",
+				id.Namespace, id.Name, id.GroupVersionKind().String(), getErr)
+		}
+		*live = fresh
+		manager := kube.ManagedFieldsManager
+		patch, patchErr := csaupgrade.UpgradeManagedFieldsPatch(
+			fresh, sets.New(manager), manager)
+		if patchErr != nil {
+			return fmt.Errorf("failed to upgrade managed fields for object %s/%s %s: %w",
+				id.Namespace, id.Name, id.GroupVersionKind().String(), patchErr)
+		}
+		if len(patch) == 0 {
+			limitation = ""
+			return nil
+		}
+		limitation = LimitationManagedFieldsMigration
+		if jsonErr := cluster.JSONPatch(ctx, id, patch); jsonErr != nil {
+			if !apierrors.IsConflict(jsonErr) {
+				return fmt.Errorf("failed to patch object to upgrade CSA field manager %s/%s %s: %w",
+					id.Namespace, id.Name, id.GroupVersionKind().String(), jsonErr)
+			}
+			return jsonErr
+		}
+		return nil
+	})
+	return limitation, err
+}

--- a/internal/predict/types.go
+++ b/internal/predict/types.go
@@ -1,0 +1,132 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"deployah.dev/deployah/internal/helm"
+)
+
+// LimitationManagedFieldsMigration marks a [Result] whose Predicted object
+// is not an exact Helm write: install adoption needed a managed-fields
+// JSON patch that server dry-run accepted, but that patch was not
+// persisted before the SSA dry-run.
+const LimitationManagedFieldsMigration = "managed-fields-migration"
+
+// Action is the semantic Kubernetes operation [Predict] would perform for
+// one resource. The zero value is invalid.
+type Action int
+
+const (
+	// ActionCreate is a Desired resource with no live object.
+	ActionCreate Action = iota + 1
+	// ActionUpdate is a Desired write that would change live state, or an
+	// install adoption whose prediction is limited.
+	ActionUpdate
+	// ActionDelete is a Previous resource that Helm would prune.
+	ActionDelete
+	// ActionNoOp is no observable change: already gone, keep policy, or
+	// normalized Live equals Predicted.
+	ActionNoOp
+)
+
+func (a Action) String() string {
+	switch a {
+	case ActionCreate:
+		return "Create"
+	case ActionUpdate:
+		return "Update"
+	case ActionDelete:
+		return "Delete"
+	case ActionNoOp:
+		return "NoOp"
+	default:
+		return fmt.Sprintf("Action(%d)", int(a))
+	}
+}
+
+// Identity is one Kubernetes object's Helm-facing identity. Group, Kind,
+// Namespace, and Name are used for prune matching. Version is used for
+// new-to-release matching and API requests.
+type Identity struct {
+	Group     string
+	Version   string
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+// Input is one Helm-resource prediction request. SSA is an invariant, not
+// a field. Previous must be [helm.ReleasePrep.Current] Manifest on
+// upgrade and empty on install.
+type Input struct {
+	Operation   helm.Operation
+	ReleaseName string
+	Namespace   string
+	Previous    string
+	Desired     string
+}
+
+// Result is the prediction for one flattened resource.
+//
+// Predicted is nil when the object would be gone after delete or was
+// already absent, or when Limitation is set and an exact predicted
+// state is unavailable. Keep-policy NoOp sets Predicted to a DeepCopy
+// of Live. Action plus Limitation disambiguates a nil Predicted.
+type Result struct {
+	Identity   Identity
+	Action     Action
+	Live       *unstructured.Unstructured
+	Predicted  *unstructured.Unstructured
+	Limitation string
+}
+
+// InputFromPrep builds an [Input] from Stage A release prep. It fails
+// closed: nil prep, an unknown or zero Operation, upgrade with a nil
+// Current, and install with a non-nil Current are errors.
+func InputFromPrep(prep *helm.ReleasePrep, name, namespace, desired string) (Input, error) {
+	if prep == nil {
+		return Input{}, errors.New("release prep is required")
+	}
+	switch prep.Operation {
+	case helm.OperationInstall:
+		if prep.Current != nil {
+			return Input{}, errors.New("install prep must not have a current release")
+		}
+		return Input{
+			Operation:   helm.OperationInstall,
+			ReleaseName: name,
+			Namespace:   namespace,
+			Desired:     desired,
+		}, nil
+	case helm.OperationUpgrade:
+		if prep.Current == nil {
+			return Input{}, errors.New("upgrade prep requires a current release")
+		}
+		return Input{
+			Operation:   helm.OperationUpgrade,
+			ReleaseName: name,
+			Namespace:   namespace,
+			Previous:    prep.Current.Manifest,
+			Desired:     desired,
+		}, nil
+	default:
+		return Input{}, fmt.Errorf("invalid helm operation %d", prep.Operation)
+	}
+}

--- a/internal/predict/types_test.go
+++ b/internal/predict/types_test.go
@@ -1,0 +1,97 @@
+// Copyright 2025 The Deployah Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predict_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"deployah.dev/deployah/internal/helm"
+	"deployah.dev/deployah/internal/predict"
+
+	v1 "helm.sh/helm/v4/pkg/release/v1"
+)
+
+func TestActionString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "Create", predict.ActionCreate.String())
+	assert.Equal(t, "Update", predict.ActionUpdate.String())
+	assert.Equal(t, "Delete", predict.ActionDelete.String())
+	assert.Equal(t, "NoOp", predict.ActionNoOp.String())
+	assert.Equal(t, "Action(0)", predict.Action(0).String())
+}
+
+func TestInputFromPrep(t *testing.T) {
+	t.Parallel()
+
+	desired := configMapYAML("app", "prod", "next")
+	current := &v1.Release{Name: "web", Manifest: configMapYAML("app", "prod", "prev")}
+
+	t.Run("nil prep", func(t *testing.T) {
+		t.Parallel()
+		_, err := predict.InputFromPrep(nil, "web", "prod", desired)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "release prep is required")
+	})
+
+	t.Run("zero operation", func(t *testing.T) {
+		t.Parallel()
+		_, err := predict.InputFromPrep(&helm.ReleasePrep{}, "web", "prod", desired)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invalid helm operation")
+	})
+
+	t.Run("upgrade without current", func(t *testing.T) {
+		t.Parallel()
+		_, err := predict.InputFromPrep(&helm.ReleasePrep{Operation: helm.OperationUpgrade}, "web", "prod", desired)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "upgrade prep requires a current release")
+	})
+
+	t.Run("install with current", func(t *testing.T) {
+		t.Parallel()
+		_, err := predict.InputFromPrep(&helm.ReleasePrep{
+			Operation: helm.OperationInstall,
+			Current:   current,
+		}, "web", "prod", desired)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "install prep must not have a current release")
+	})
+
+	t.Run("install without current", func(t *testing.T) {
+		t.Parallel()
+		in, err := predict.InputFromPrep(&helm.ReleasePrep{Operation: helm.OperationInstall}, "web", "prod", desired)
+		require.NoError(t, err)
+		assert.Equal(t, helm.OperationInstall, in.Operation)
+		assert.Equal(t, "web", in.ReleaseName)
+		assert.Equal(t, "prod", in.Namespace)
+		assert.Empty(t, in.Previous)
+		assert.Equal(t, desired, in.Desired)
+	})
+
+	t.Run("upgrade uses current manifest", func(t *testing.T) {
+		t.Parallel()
+		in, err := predict.InputFromPrep(&helm.ReleasePrep{
+			Operation: helm.OperationUpgrade,
+			Current:   current,
+		}, "web", "prod", desired)
+		require.NoError(t, err)
+		assert.Equal(t, helm.OperationUpgrade, in.Operation)
+		assert.Equal(t, current.Manifest, in.Previous)
+		assert.Equal(t, desired, in.Desired)
+	})
+}


### PR DESCRIPTION
## Summary

- Add `internal/predict` so Deployah can ask what Helm SSA would write, using server dry-run only.
- Keep it a library. `deployah plan` and deploy still use the old planner.
- Exact prediction needs the release namespace and every GVK to exist. A missing namespace or unmapped kind returns the native API error.

## Related

Refs #131

## Test plan

- [x] Unit tests added/updated
- [ ] Scenario under `scenarios/` (if behavior changes)
- [x] `golangci-lint` on `./internal/predict`; `go test ./internal/predict/... -race`
- [x] Kind: `go test ./internal/e2e -tags e2e -run 'TestE2E/TestPredict'`
- [ ] Manual smoke (command + expected result), if user-facing

## Labels

- [x] One of: `kind/feature`, `kind/bug`, `kind/docs`, `kind/chore` (`kind/chore`)
- [ ] Add `breaking-change` if this breaks existing CLI or config behavior
- [x] Add `skip-changelog` for internal-only PRs that should not appear in notes

## Checklist

- [x] Title is short and imperative (matches commit style)
- [x] Docs / CLI help updated when user-facing (`README.md`, `docs/cli/`) (package godoc only; no CLI change)
- [x] No secrets or local-only paths in the diff